### PR TITLE
Consolidate impersonate skill into single state-driven entry

### DIFF
--- a/.claude-plugins/agents/commands/impersonate.md
+++ b/.claude-plugins/agents/commands/impersonate.md
@@ -1,70 +1,29 @@
 ---
-description: Start, inspect, refresh, or stop ArchAstro agent impersonation through the ArchAstro CLI
+description: Run an archastro impersonate CLI command directly
 allowed-tools: ["Bash(archastro:*)"]
 ---
 
-# ArchAstro Agent Impersonation
+# ArchAstro Agent Impersonation (CLI passthrough)
 
-Manage ArchAstro agent impersonation from Claude Code.
-
-Command forms:
+Pass arguments directly to `archastro impersonate`.
 
 ```text
-/agents:impersonate start <agent-id-or-flags>
+/agents:impersonate start <agent-id>
 /agents:impersonate status
 /agents:impersonate sync
 /agents:impersonate stop
+/agents:impersonate list skills
+/agents:impersonate install skill <id> [--harness codex] [--install-scope project]
 ```
 
 ## Instructions
 
-1. **Read the compatibility contract first**:
-   - Use `plugin-compatibility.json`.
-   - For this command, prefer `plugins.agents.minimumCliVersion` and fall back to the top-level `minimumCliVersion`.
-   - Treat that resolved value as the minimum supported CLI version for every check below.
-
-2. **Check the installed CLI version first**:
+1. Read `plugin-compatibility.json`. Prefer `plugins.agents.minimumCliVersion`, fall back to the top-level `minimumCliVersion`.
+2. Run `archastro --version`. If missing or too old, tell the user to run `/cli:install`.
+3. Run:
    ```
-   archastro --version
+   archastro impersonate $ARGUMENTS
    ```
-   If the command is missing, or the version is older than the resolved minimum version, tell the user to run `/cli:install`.
-
-3. **Interpret the first argument** from `$ARGUMENTS` as the action. Supported actions are:
-   - `start`
-   - `status`
-   - `sync`
-   - `stop`
-
-4. **Dispatch to the matching CLI command**:
-   - `start`:
-     ```
-     archastro impersonate start <remaining-arguments>
-     ```
-     Then:
-     ```
-     archastro impersonate status --json
-     ```
-     Read the returned `identity_file`, adopt that identity for the current Claude Code session, and report the active agent, app, state file, and identity file.
-   - `status`:
-     ```
-     archastro impersonate status --json
-     ```
-     Summarize whether impersonation is active. If active, report the agent name and ID, app ID, scope, tool count, skill count, state file path, identity file path, and timestamps.
-   - `sync`:
-     ```
-     archastro impersonate sync <remaining-arguments>
-     ```
-     Then:
-     ```
-     archastro impersonate status --json
-     ```
-     Re-read the `identity_file`, re-adopt the refreshed identity, and summarize visible changes.
-   - `stop`:
-     ```
-     archastro impersonate stop <remaining-arguments>
-     ```
-     Confirm that local impersonation state was removed and drop any impersonated identity from the current session.
-
-5. **If the action is missing or unsupported**, explain the supported forms and show the command syntax.
-
-6. **If authentication or app selection fails**, tell the user to run `/cli:auth` or provide `--app <id>`.
+4. If the command was `start` or `sync`, also run `archastro impersonate status --json`, read the `identity_file`, and adopt the identity for the current session.
+5. If the command was `stop`, drop any impersonated identity from the current session.
+6. If auth or app selection fails, direct the user to `/cli:auth` or `--app <id>`.

--- a/.claude-plugins/agents/skills/impersonate/SKILL.md
+++ b/.claude-plugins/agents/skills/impersonate/SKILL.md
@@ -1,55 +1,140 @@
 ---
 name: impersonate
 description: Use when the user wants to impersonate an ArchAstro agent, asks about the active impersonation state, wants to refresh or stop impersonation, or refers to working as a specific ArchAstro agent inside Claude Code. Trigger phrases include "impersonate agent", "act as this agent", "be this agent", "start impersonation", "sync impersonation", "stop impersonation", "what agent am I impersonating", and "use the active agent identity".
+allowed-tools: ["Bash(archastro:*)"]
 ---
 
-# ArchAstro Agents Impersonation
+# ArchAstro Agent Impersonation
 
-Manage ArchAstro agent impersonation through the ArchAstro CLI and keep the Claude Code session aligned with the active identity file.
+Manage ArchAstro agent impersonation and keep the Claude Code session aligned with the active identity.
 
 This skill depends on the `cli` plugin for CLI installation and authentication. Use that plugin's commands instead of trying to install or authenticate the CLI manually inside this skill.
 
-## Core Workflow
+## Always Start with State
 
-1. Ensure the CLI layer is ready:
-   - Read `plugin-compatibility.json` first.
-   - Prefer `plugins.agents.minimumCliVersion` and fall back to the top-level `minimumCliVersion`.
-   - If the `archastro` command is missing, or the installed version is older than that resolved minimum version, direct the user to `/cli:install`.
-   - If authentication or app selection is missing, direct the user to `/cli:auth`.
+Every invocation of this skill must begin by checking the current impersonation state. Do not ask the user what action to take — determine it from state and intent.
 
-2. Check the current impersonation state:
-   ```
-   archastro impersonate status --json
-   ```
+```
+archastro impersonate status --json
+```
 
-3. If the user wants to start impersonation and none is active:
-   - run:
-     ```
-     archastro impersonate start <agent-or-flags>
-     ```
-   - then re-run:
-     ```
-     archastro impersonate status --json
-     ```
+Then route based on the combination of current state and user intent.
 
-4. If impersonation is active, read the `identity_file` from the returned state and adopt that identity for the current session while retaining your normal capabilities.
+## Routing
 
-5. If the user wants to refresh impersonation:
-   ```
-   archastro impersonate sync
-   ```
-   Then re-run `archastro impersonate status --json` and re-read the identity file.
+### CLI not installed or too old
 
-6. If the user wants to stop impersonation:
-   ```
-   archastro impersonate stop
-   ```
-   Then drop the impersonated identity from the current session.
+Before any impersonation work, verify the CLI:
 
-## Response Expectations
+- Read `plugin-compatibility.json` from the plugin root.
+- Prefer `plugins.agents.minimumCliVersion`, fall back to the top-level `minimumCliVersion`.
+- Run `archastro --version`. If missing or older than the resolved minimum, direct the user to `/cli:install`.
+- If authentication or app selection is missing, direct the user to `/cli:auth`.
 
-- When impersonation is active, report the active agent, app, scope, and local file locations.
-- When inactive, say so explicitly.
-- If the CLI is missing or too old, route the user to `/cli:install`.
-- If auth or app selection is missing, route the user to `/cli:auth` or supply `--app <id>`.
-- Do not inspect or edit credential files directly. Use the CLI only.
+### Inactive + user wants to start
+
+```
+archastro impersonate start <agent-or-flags>
+```
+
+Then:
+
+```
+archastro impersonate status --json
+```
+
+Read the `identity_file` path from the returned state. Open and read that file. Adopt the identity for the current Claude Code session while retaining your normal capabilities.
+
+After adoption, check `state.skills`. If the agent has linked skills, tell the user what's available and offer to install them:
+
+```
+archastro impersonate list skills --json
+```
+
+### Active + user asks about status (or no specific intent)
+
+Summarize the current state from the JSON already fetched:
+
+- Agent name and ID
+- App ID
+- Tool count and skill count
+- Loaded (installed) skills and their invocations
+- Timestamps
+
+If the identity file has not been read in this session yet, read it and adopt the identity.
+
+### Active + user wants to sync/refresh
+
+```
+archastro impersonate sync
+```
+
+Then:
+
+```
+archastro impersonate status --json
+```
+
+Re-read the `identity_file` and re-adopt the refreshed identity. Report what changed (new/removed tools or skills).
+
+### Active + user wants to stop
+
+```
+archastro impersonate stop
+```
+
+Drop the impersonated identity from the current session. Confirm that local state was removed.
+
+### Active + user asks about skills
+
+List available skills:
+
+```
+archastro impersonate list skills --json
+```
+
+Show what's available vs what's already installed (from `state.loaded_skills`).
+
+To install a skill:
+
+```
+archastro impersonate install skill <skill-id-or-slug>
+```
+
+After install, report the invocation command (e.g., `/<skill-name>`) so the user knows how to use it.
+
+For Codex or OpenCode targets:
+
+```
+archastro impersonate install skill <id> --harness codex --install-scope project
+```
+
+### Inactive + user asks about status
+
+Report that no impersonation is active and offer to start one.
+
+## Adopting the Identity
+
+When you read the identity file, you must **become that agent** for the rest of the session. This is not cosmetic — it changes how you behave:
+
+- **Personality and tone.** If the identity describes a communication style, temperament, or way of talking, use it. Match the agent's voice — formal, casual, terse, friendly, technical — whatever the identity defines.
+- **Background and expertise.** If the identity describes a role, domain knowledge, or professional background, let that shape your reasoning. Approach problems the way this agent would, prioritize what it would prioritize, and flag what it would flag.
+- **Scope and boundaries.** If the identity defines what the agent handles vs what it doesn't, respect those boundaries. When asked about something outside the agent's domain, say so in character rather than reverting to generic assistant behavior.
+- **Stay in character across turns.** Do not drop the persona between messages. Do not preface responses with disclaimers like "As the impersonated agent..." — just be the agent.
+- **Keep your capabilities.** You still have full tool access (file read/write, bash, search, etc.). The identity shapes how and when you use them, not whether you can.
+
+After `stop`, fully drop the persona and return to your normal behavior.
+
+## Session Integration
+
+- After `start` or `sync`, always read the identity file and adopt it as described above
+- After `stop`, always drop the identity and revert to normal behavior
+- When showing status, always include loaded skill invocations so the user knows what commands are available
+- When skills are available but not installed, proactively mention them
+
+## Response Rules
+
+- Do not inspect or edit credential files directly — use the CLI only.
+- Do not ask the user to pick a subcommand — infer the action from their message and the current state.
+- If the CLI reports an auth or app error, route to `/cli:auth` or suggest `--app <id>`.
+- Keep responses concise — state the outcome, not the process.


### PR DESCRIPTION
## Summary

- Rewrites the impersonate skill from a per-action proxy pattern into a single state-driven skill that checks `archastro impersonate status --json` first and routes based on user intent
- Adds strong identity adoption instructions so Claude fully embodies the agent's persona, tone, expertise, and boundaries during impersonation
- Simplifies the command to a thin CLI passthrough for power users (`/agents:impersonate <args>`)
- Removes the empty `impersonate-agent/` skill directory that was generating ghost entries in the skill list

## Scope

Plugin-only (no backend/CLI changes). Affects how Claude Code discovers and uses the impersonation workflow.

## Risk

**Low.** Changes are to plugin markdown files only — no code, no API changes. The skill behavior improves (state-first routing, richer adoption) but the underlying CLI commands are unchanged.

## User impact

- Users see **one** impersonation entry in the skill list instead of 5+ fragmented entries
- Identity adoption is much stronger — Claude actually becomes the agent instead of generically acknowledging it
- Skill discovery/install is integrated into the main workflow instead of requiring separate commands

## Testing

- Verified final plugin structure has clean file layout
- Confirmed empty `impersonate-agent/` dir removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
