### PR TITLE
fix(plugins): add org mode login flow to auth command

### DIFF
--- a/.claude-plugins/cli/commands/auth.md
+++ b/.claude-plugins/cli/commands/auth.md
@@ -1,5 +1,5 @@
 ---
-description: Authenticate with the ArchAstro developer platform
+description: Authenticate with the ArchAstro developer platform (developer or org mode)
 allowed-tools: ["Bash(archastro:*)"]
 ---
 
@@ -26,30 +26,46 @@ Authenticate the user with the ArchAstro developer platform via browser-based lo
    ```
    If the user is already authenticated, show their status and ask if they want to re-authenticate.
 
-4. **Reset any stale settings overrides** that may point to localhost:
+4. **Determine the auth mode**:
+
+   Ask the user whether they want **developer mode** or **org mode**:
+   - **Developer mode**: For building and managing apps. This is the default.
+   - **Org mode**: For logging in as a user within a specific app/organization. Requires the **app slug** — the user must know this in advance.
+
+5. **Reset any stale settings overrides** that may point to localhost:
    ```
    archastro settings reset
    ```
    This ensures the CLI uses the production URLs.
 
-5. **Start the login flow**:
+6. **Start the login flow**:
+
+   **Developer mode:**
    ```
    archastro auth login
    ```
+
+   **Org mode** (the `--app` flag is a global option, not shown in `login --help`):
+   ```
+   archastro auth login --app <app-slug>
+   ```
+
    Use `run_in_background: true` so the browser-based auth flow runs while you remain responsive.
 
    The CLI will open the user's browser to https://developers.archastro.ai for authentication and print a URL in case the browser doesn't open automatically.
 
-6. **Tell the user** the auth flow is running and they should complete login in their browser. Let them know you're available to keep working on other things while waiting.
+7. **Tell the user** the auth flow is running and they should complete login in their browser. Let them know you're available to keep working on other things while waiting.
 
-7. **When the user says they've logged in** (or you're ready to check), wait for the command to finish and then re-check status.
+8. **When the user says they've logged in** (or you're ready to check), wait for the command to finish and then re-check status.
 
-8. **On success**, confirm authentication succeeded and show their status:
+9. **On success**, confirm authentication succeeded and show their status:
    ```
    archastro auth status
    ```
+   For org mode, verify the output shows `Auth mode: org` and the correct app/org name.
 
-9. **On failure**, show the error and suggest:
-   - Check their internet connection
-   - Try `archastro settings reset` if URLs look wrong
-   - Try again with `archastro auth login`
+10. **On failure**, show the error and suggest:
+    - Check their internet connection
+    - Try `archastro settings reset` if URLs look wrong
+    - `no-access` error means the user doesn't have org access to that app — verify the slug or ask an org admin for an invite
+    - Try again with `archastro auth login` (or `--app <slug>` for org mode)


### PR DESCRIPTION
## Summary

- Auth command now asks whether the user wants developer or org mode
- Documents `--app <slug>` flag for org login (global flag, not shown in `login --help`)
- Adds org-specific verification (confirms `Auth mode: org` on success)
- Adds `no-access` error handling with actionable suggestions

## Scope

Plugin-only. One file changed: `.claude-plugins/cli/commands/auth.md`.

## Risk

**Low.** Markdown command file only. Existing developer login flow unchanged — this adds an org mode branch to the instructions.

## User impact

Users who want org mode login are now guided through the flow instead of having to discover `--app <slug>` by trial and error.

## Testing

- Validated against a real org login session that surfaced these pain points
- Developer mode flow unchanged from previous version

🤖 Generated with [Claude Code](https://claude.com/claude-code)
