### PR TITLE
docs(skills): update chat skill for --wait session streaming

### DIFF
--- a/.claude-plugins/cli/skills/chat/SKILL.md
+++ b/.claude-plugins/cli/skills/chat/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: chat
-description: Use when the user wants to send a message to an ArchAstro agent, view a thread conversation, check for agent responses, or interact with an agent in a thread. Trigger phrases include "send a message", "ask the agent", "what did the agent say", "show the conversation", "check the thread", "talk to the agent", "message the agent".
+description: Use when the user wants to send a message to an ArchAstro agent, ask an agent a question, view a thread conversation, check for agent responses, or interact with an agent. Trigger phrases include "send a message", "ask the agent", "what did the agent say", "show the conversation", "check the thread", "talk to the agent", "message the agent", "create a session".
 allowed-tools: ["Bash(archastro:*)"]
 ---
 
 # ArchAstro Agent Chat
 
-Send messages to agents in threads and view their responses.
+Send messages to agents and view their responses.
 
 This skill depends on the `cli` plugin for CLI installation and authentication. Use that plugin's commands instead of trying to install or authenticate the CLI manually inside this skill.
 
@@ -14,8 +14,31 @@ This skill depends on the `cli` plugin for CLI installation and authentication. 
 
 Every invocation must begin by understanding the current context. Determine:
 
-1. Does the user have a thread in mind, or do they need one created?
-2. Are they sending a new message, or checking for responses?
+1. Does the user want a quick one-off question (use agent session) or an ongoing conversation (use thread)?
+2. Do they have an existing session or thread, or need a new one?
+
+## Two Interaction Models
+
+### Agent Sessions (recommended for most use cases)
+
+Direct 1:1 conversation with an agent. Use `--wait` to stream the response via SSE.
+
+**One-shot question** — put the question in `--instructions` and use `--wait`:
+```
+archastro create agentsession --agent <agent-id> --instructions "What are the open issues?" --wait
+```
+The agent processes the instructions as its task. `--wait` streams updates until completion.
+
+**Multi-turn conversation** — create session, send messages with `exec --wait`:
+```
+archastro create agentsession --agent <agent-id> --thread-id <thread-id> --instructions "Respond to messages"
+archastro exec agentsession <session-id> -m "What are the open issues?" --wait
+```
+`exec --wait` blocks and streams the agent's response in real-time. Without `--wait`, exec returns immediately after sending.
+
+### Threads (for multi-participant conversations)
+
+Threads support multiple users and agents. Use when you need ongoing conversation context or multiple participants.
 
 ## Routing
 
@@ -28,13 +51,41 @@ Before any chat work, verify the CLI:
 - Run `archastro --version`. If missing or older than the resolved minimum, direct the user to `/cli:install`.
 - If authentication or app selection is missing, direct the user to `/cli:auth`.
 
-### User wants to send a message
+### User wants to ask an agent a question
+
+**Preferred: agent session with `--wait`**
+
+```
+archastro create agentsession --agent <agent-id> --instructions "<question>" --wait
+```
+This creates the session, processes the question, and streams the result — all in one command.
+
+For longer timeouts:
+```
+archastro create agentsession --agent <agent-id> --instructions "<question>" --wait --timeout 300
+```
+
+**Alternative: exec with `--wait`**
+
+If you need to send follow-up messages to an existing session:
+```
+archastro exec agentsession <session-id> -m "<question>" --wait
+```
+
+**Without `--wait`** (fire-and-forget):
+```
+archastro create agentsession --agent <agent-id> --instructions "<question>"
+archastro describe agentsession <session-id> --follow
+```
+Use `describe --follow` to stream updates on a session created without `--wait`.
+
+### User wants to send a thread message
 
 1. **Determine the sender ID**:
 
-   **Org mode** (authenticated as an app user): Get the user's ID from `archastro auth status`.
+   **Org mode**: Get the user's ID from `archastro auth status`.
 
-   **Developer mode** (authenticated as a developer): Look up thread members:
+   **Developer mode**: Look up thread members:
    ```
    archastro list threadmembers --thread <thread-id>
    ```
@@ -44,55 +95,30 @@ Before any chat work, verify the CLI:
    archastro create threadmessage --thread <thread-id> --user-id <user-id> --content "..." \
      --wait --wait-timeout 300
    ```
-   Use `run_in_background: true` so you remain responsive while waiting.
 
-   - `--wait-settle 5` (default) waits 5 seconds after the last message before returning, in case the agent sends multiple messages.
-   - Set `--wait-timeout` generously — agent responses often take 30–90 seconds, sometimes longer.
-
-3. **Tell the user** the message was sent and the agent is processing. Let them know you're available while waiting.
-
-4. **When the response arrives**, read the full content:
+3. **When the response arrives**, read the full content:
    ```
    archastro list threadmessages --thread <thread-id> --full
    ```
-
-5. **Present the response**: summarize key points, highlight action items or decisions, offer to send a follow-up.
 
 ### User wants to view a conversation
 
-1. **Fetch messages with full content**:
-   ```
-   archastro list threadmessages --thread <thread-id> --full
-   ```
-   Always use `--full` — the default table view truncates content to 60 characters.
-
-   For programmatic processing:
-   ```
-   archastro list threadmessages --thread <thread-id> --json
-   ```
-
-2. **Present the conversation**:
-   - Summarize the overall flow (who said what, key decisions)
-   - For each message, show the sender and a concise summary
-   - Highlight agent feedback, action items, or decisions
-   - Offer to expand any individual message on request
+```
+archastro list threadmessages --thread <thread-id> --full
+```
+Always use `--full` — the default table view truncates content.
 
 ### User needs a new thread
 
-1. **Create the thread**:
+1. Create the thread:
    ```
    archastro create thread --title "..." --user <user-id>
    ```
-   The `--user` is the thread owner. Note the thread ID from the output.
 
-2. **Add members** — agents and users who participate:
+2. Add members:
    ```
    archastro create threadmember --thread <thread-id> --agent-id <agent-id>
-   archastro create threadmember --thread <thread-id> --user-id <user-id>
    ```
-   A thread typically needs at least one agent and one user before messaging.
-
-3. Once members are added, route to "User wants to send a message" if they have something to say.
 
 ## Response Rules
 
@@ -100,3 +126,5 @@ Before any chat work, verify the CLI:
 - Do not ask the user to pick a subcommand — infer the action from their message.
 - If the CLI reports an auth or app error, route to `/cli:auth` or suggest `--app <id>`.
 - Keep responses concise — state the outcome, not the process.
+- **Prefer agent sessions over threads** for simple question/answer interactions.
+- **Always use `--wait`** when the user expects to see the agent's response.


### PR DESCRIPTION
## Summary

Update the chat skill to document agent session streaming via `--wait` flag.

- Add agent sessions as the primary interaction model (simpler than threads for Q&A)
- Document `create agentsession --wait` for one-shot questions
- Document `exec agentsession --wait` for multi-turn conversations
- Keep threads as secondary path for multi-participant conversations
- Add "Always use `--wait`" to response rules

## Context

Companion to an upstream CLI change that adds `--wait` SSE streaming to both `create agentsession` and `exec agentsession`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
