### PR TITLE
docs(skills): document participate routine requirements for thread interaction

### DIFF
--- a/.claude-plugins/cli/skills/agent_authoring/SKILL.md
+++ b/.claude-plugins/cli/skills/agent_authoring/SKILL.md
@@ -85,7 +85,14 @@ Before any authoring work, verify the CLI:
 
 ### Routine configs inside templates
 
-- Scheduled routines need both:
+- **Participate routines** (conversational agents that auto-respond to thread messages):
+  - `event_type: thread.session.join`
+  - `handler_type: preset`
+  - `preset_name: participate`
+  - `status: active`
+  - The agent also needs an `archastro/thread` installation for thread integration.
+  - Participate routines fire automatically when a message is sent to a thread where the agent is a member. Use `archastro create threadmessage --wait` to send a message and wait for the agent's response in the thread.
+- **Scheduled routines** need both:
   - `schedule: "<cron>"`
   - `event_type: schedule.cron`
 - Do not put schedules under nested `event_config.schedule`.

--- a/.claude-plugins/cli/skills/agent_deploy/SKILL.md
+++ b/.claude-plugins/cli/skills/agent_deploy/SKILL.md
@@ -71,6 +71,12 @@ Route to the `agent_authoring` skill before deploying. That skill owns:
 
 ### User wants to add an agent to a thread
 
+**Prerequisites:** For the agent to auto-respond to messages, it needs:
+- A **participate routine** (`event_type: thread.session.join`, `preset_name: participate`, `status: active`)
+- An **`archastro/thread` installation**
+
+If the agent was deployed via `archastro deploy agent`, these are already provisioned from the template. If the agent was created manually, verify with `archastro list agentroutines --agent <id>` and `archastro list agentinstallations --agent <id>`.
+
 1. **If no thread exists**, create one:
    ```
    archastro create thread --title "..." --user <user-id>
@@ -86,7 +92,10 @@ Route to the `agent_authoring` skill before deploying. That skill owns:
    archastro create threadmember --thread <thread-id> --user-id <user-id>
    ```
 
-4. **Confirm** the thread is ready and offer to send the first message.
+4. **Send the first message with `--wait`** to trigger the agent and see its response:
+   ```
+   archastro create threadmessage --thread <thread-id> --user-id <user-id> -c "hello" --wait
+   ```
 
 ### User asks about existing agents
 

--- a/.claude-plugins/cli/skills/chat/SKILL.md
+++ b/.claude-plugins/cli/skills/chat/SKILL.md
@@ -110,12 +110,14 @@ Always use `--full` — the default table view truncates content.
 
 ### User needs a new thread
 
+Before creating a thread, verify the agent is set up to respond. It needs a participate routine and an `archastro/thread` installation. If the agent was deployed via `archastro deploy agent`, these are already provisioned. If not, route to `agent_deploy` to set them up first.
+
 1. Create the thread:
    ```
    archastro create thread --title "..." --user <user-id>
    ```
 
-2. Add members:
+2. Add the agent:
    ```
    archastro create threadmember --thread <thread-id> --agent-id <agent-id>
    ```


### PR DESCRIPTION
## Summary

- Skills didn't mention that agents need a participate routine + `archastro/thread` installation to auto-respond in threads
- Claude sessions following these skills would create threads, add agents, send messages — and get silence

## What changed

- **agent_authoring**: Added participate routine config requirements alongside scheduled routines
- **agent_deploy**: Added prerequisites check before "add agent to thread" flow, replaced "confirm and offer first message" with explicit `create threadmessage --wait`
- **chat**: Added pre-flight check that agent has participate routine + installation before creating a new thread

## Companion PR

Same change in archagents repo (with `archagent` naming).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
