### PR TITLE
docs(impersonate): document integration tool limitation (closes #8)

### DIFF
--- a/.claude-plugins/archastro/skills/impersonate/SKILL.md
+++ b/.claude-plugins/archastro/skills/impersonate/SKILL.md
@@ -132,6 +132,11 @@ After `stop`, fully drop the persona and return to your normal behavior.
 - When showing status, always include loaded skill invocations so the user knows what commands are available
 - When skills are available but not installed, proactively mention them
 
+## Limitations
+
+- **Integration tools do not resolve during impersonation.** Tools backed by server-side integrations (GitHub, Slack, Gmail, etc.) require OAuth credentials that cannot be exported locally. Only builtin tools and custom script tools are available.
+- For agents that rely primarily on integrations, use agent sessions (`archastro create agentsession --agent <id> --wait`) instead of impersonation.
+
 ## Response Rules
 
 - Do not inspect or edit credential files directly — use the CLI only.


### PR DESCRIPTION
Adds a Limitations section to the impersonate skill noting that integration-backed tools (GitHub, Slack, Gmail, etc.) do not resolve during impersonation. Only builtin and custom script tools are available locally. Points users to agent sessions as the alternative for integration-heavy agents.

4-line addition before the Response Rules section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)