### PR TITLE
feat: generate plugin content from sources/ with CI drift check

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "archastro",
+  "interface": {
+    "displayName": "ArchAstro"
+  },
+  "plugins": [
+    {
+      "name": "archastro",
+      "source": {
+        "source": "local",
+        "path": "./plugins/archastro"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Development"
+    }
+  ]
+}

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "archastro",
       "source": "./.claude-plugins/archastro",
       "description": "The complete ArchAstro developer plugin: install and authenticate the public ArchAstro CLI, then author and deploy agents, chat with running agents, and impersonate agents from Claude Code.",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "category": "development",
       "tags": [
         "archastro",

--- a/.claude-plugins/archastro/.claude-plugin/plugin.json
+++ b/.claude-plugins/archastro/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "archastro",
   "description": "The complete ArchAstro developer plugin: install and authenticate the public ArchAstro CLI, then author and deploy agents, chat with running agents, and impersonate agents from Claude Code.",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "author": { "name": "ArchAstro" },
   "license": "MIT",
   "keywords": [

--- a/.github/workflows/check-plugin-content.yml
+++ b/.github/workflows/check-plugin-content.yml
@@ -1,0 +1,24 @@
+name: check-plugin-content
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up Python
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install pyyaml==6.0.2
+
+      - name: Verify generated plugin content is in sync with sources/
+        run: python3 scripts/generate-plugin-content.py --check

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+scripts/__pycache__/

--- a/plugins/archastro/.codex-plugin/plugin.json
+++ b/plugins/archastro/.codex-plugin/plugin.json
@@ -1,0 +1,43 @@
+{
+  "name": "archastro",
+  "version": "0.3.1",
+  "description": "Deploy, manage, chat with, and impersonate ArchAstro agents from Codex through the ArchAstro CLI.",
+  "author": {
+    "name": "ArchAstro",
+    "email": "dev@archastro.com",
+    "url": "https://github.com/ArchAstro"
+  },
+  "homepage": "https://github.com/ArchAstro/archastro-cli",
+  "repository": "https://github.com/ArchAstro/archastro-cli",
+  "license": "MIT",
+  "keywords": [
+    "archastro",
+    "cli",
+    "agent-authoring",
+    "deployment",
+    "impersonation",
+    "developer-platform",
+    "codex"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "ArchAstro",
+    "shortDescription": "Complete ArchAstro workflows for Codex: authoring, deployment, chat, and impersonation.",
+    "longDescription": "Use the public ArchAstro CLI from Codex to author agent configs, deploy agents, chat with running agents, and impersonate deployed ArchAstro agents from the current session.",
+    "developerName": "ArchAstro",
+    "category": "Development",
+    "capabilities": [
+      "Interactive",
+      "Write",
+      "Shell"
+    ],
+    "websiteURL": "https://github.com/ArchAstro/archastro-cli",
+    "defaultPrompt": [
+      "Author a config-driven ArchAstro agent.",
+      "Deploy an ArchAstro agent.",
+      "Chat with a deployed ArchAstro agent.",
+      "Start impersonating an ArchAstro agent."
+    ],
+    "brandColor": "#0F766E"
+  }
+}

--- a/plugins/archastro/skills/agent_authoring/SKILL.md
+++ b/plugins/archastro/skills/agent_authoring/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: agent_authoring
+description: Use when the user wants to create or edit an ArchAstro agent's config files before deployment, including AgentTemplate files, Script configs, custom tools, routines, and environment setup. Trigger phrases include "build this agent", "write the template", "create the scripts", "set up the routines", "author this agent config".
+allowed-tools: ["Bash(archastro:*)"]
+---
+
+# ArchAstro Agent Authoring
+
+Create or update the config files for a config-driven ArchAstro agent before deployment.
+
+This skill assumes the ArchAstro CLI is already installed and authenticated. Install or upgrade `archastro` if missing, and run `archastro auth login` if not authenticated.
+
+## Always Start with State
+
+Every invocation must begin by understanding the current project state:
+
+```
+archastro auth status
+```
+
+If the user is in a repo, inspect whether a `configs/` directory already exists and whether the agent already has Script or AgentTemplate files.
+
+## Routing
+
+### CLI not installed or too old
+
+Before any authoring work, verify the CLI:
+
+- Read `plugin-compatibility.json` from the plugin root.
+- Prefer `plugins.archastro.minimumCliVersion`, fall back to the top-level `minimumCliVersion`.
+- Run `archastro --version`. If missing or older than the resolved minimum, instruct the user to install or upgrade `archastro`.
+- If authentication or app selection is missing, instruct the user to run `archastro auth login`.
+
+### User wants to author or modify agent configs
+
+1. **Start from CLI-backed templates, not memory**:
+   - For new config objects, use:
+     ```
+     archastro configs sample <Kind>
+     ```
+   - For Script configs, always use:
+     ```
+     archastro configs script-reference
+     archastro configs sample Script
+     ```
+     The script reference is the live source of truth. Do not invent or paraphrase the language from memory.
+
+2. **Use the standard config-driven model**:
+   - Script logic lives in `kind: Script` configs.
+   - Agent behavior lives in an `AgentTemplate`.
+   - Custom tools should use `kind: custom`, `handler_type: script`, and `config_ref` pointing at Script configs.
+   - When creating configs outside a project directory, use `-f` to read from a file:
+     ```
+     archastro create config -k AgentTemplate -f configs/agents/my-agent.yaml
+     ```
+
+3. **Validate early**:
+   ```
+   archastro configs validate
+   ```
+   Run validation before deploy whenever the user changes Script or template files.
+
+4. **Deploy through the normal flow after authoring**:
+   - If the agent has Script configs or other supporting files, sync them first:
+     ```
+     archastro configs deploy
+     ```
+     This pushes local config files (Scripts, templates) but does not create agents.
+     Skip this step if the agent only has a single AgentTemplate file — `deploy agent` handles its own config upload.
+   - Then provision the agent from its template:
+     ```
+     archastro deploy agent <yaml-file>
+     ```
+     This uploads the template config and creates the agent with its routines, tools, and installations.
+   - **Important:** `configs deploy` and `deploy agent` are different commands.
+     Use `configs deploy` to sync a directory of config files; use `deploy agent` to create an agent from a template.
+
+## Authoring Rules
+
+### Script configs
+
+- Treat the script language as a functional expression language, not a general-purpose imperative language.
+- Use `archastro configs script-reference` for exact syntax and available namespaces.
+- If a script fails validation, prefer rewriting toward the sample/reference instead of trial-and-error improvisation.
+
+### Routine configs inside templates
+
+- Scheduled routines need both:
+  - `schedule: "<cron>"`
+  - `event_type: schedule.cron`
+- Do not put schedules under nested `event_config.schedule`.
+
+### Config references
+
+- Prefer human-readable `config_ref` values that match deployed config lookup keys.
+- Do not convert refs to raw `cfg_...` IDs unless explicitly debugging a broken environment.
+
+### Environment variables
+
+- For org users, prefer org-scoped environment variables when they are sufficient for the agent's needs.
+- Do not default users into app-scoped env-var flows unless the use case truly requires app scope.
+
+## Recovery Rules
+
+- If the user asks for a brand-new Script and the language shape is unclear, run `archastro configs script-reference` before drafting.
+- If validation fails, surface the exact failing field or syntax problem. Do not immediately switch to lower-level provisioning commands.
+- If the user asks to "just create the agent" while configs are still incomplete, finish authoring and validation first, then route to `agent_deploy`.
+
+## Command Conventions
+
+- Config management uses two patterns:
+  - **Noun-first** for workflow commands: `archastro configs deploy`, `archastro configs sync`, `archastro configs validate`
+  - **Verb-first** for CRUD: `archastro list configs`, `archastro describe config <id>`, `archastro create config`
+- Do not use `archastro configs list` or `archastro configs describe` — those are not valid. Use the verb-first form.
+
+## Response Rules
+
+- Do not inspect or edit credential files directly — use the CLI only.
+- Do not ask the user to pick raw subcommands when intent is clear.
+- Keep responses concise and operational.
+- Prefer the golden path over fallback commands.

--- a/plugins/archastro/skills/agent_deploy/SKILL.md
+++ b/plugins/archastro/skills/agent_deploy/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: agent_deploy
+description: Use when the user wants to deploy an ArchAstro agent, turn a config-driven agent repo into a running agent, or get an existing agent running in a thread. Trigger phrases include "deploy agent", "deploy this agent", "set up an agent", "launch agent", "ship this agent", "get this agent running".
+allowed-tools: ["Bash(archastro:*)"]
+---
+
+# ArchAstro Agent Deployment
+
+Deploy an agent from a YAML template and get it running in a thread.
+
+This skill assumes the ArchAstro CLI is already installed and authenticated. Install or upgrade `archastro` if missing, and run `archastro auth login` if not authenticated.
+
+## Always Start with State
+
+Every invocation must begin by understanding what already exists:
+
+```
+archastro auth status
+archastro list agents
+```
+
+If the user is working from a local repo, also inspect whether a `configs/` directory already exists. Determine whether they want to:
+- deploy a new config-driven agent,
+- redeploy an existing template,
+- or work with an existing running agent.
+
+## Routing
+
+### CLI not installed or too old
+
+Before any deployment work, verify the CLI:
+
+- Read `plugin-compatibility.json` from the plugin root.
+- Prefer `plugins.archastro.minimumCliVersion`, fall back to the top-level `minimumCliVersion`.
+- Run `archastro --version`. If missing or older than the resolved minimum, instruct the user to install or upgrade `archastro`.
+- If authentication or app selection is missing, instruct the user to run `archastro auth login`.
+
+### User wants to deploy a new agent
+
+Use the config-driven golden path. Do not skip straight to `create agent`.
+
+1. **Deploy configs first**:
+   ```
+   archastro configs deploy
+   ```
+   This pushes Script and AgentTemplate configs to the server. For config-driven agents, this should happen before provisioning the agent itself.
+
+2. **Deploy the agent from the template file**:
+   ```
+   archastro deploy agent <yaml-file>
+   ```
+   This creates the full agent stack in one step: app config, agent record, routines, and installations. Note the agent ID (`agi_...`) from the output.
+
+   **Important:** Always use `deploy agent`, not `create agent`. The `create agent` command only creates the agent record without provisioning routines or installations.
+
+3. **Verify the deployment**:
+   ```
+   archastro list agents
+   ```
+
+4. **Offer next steps**: ask if the user wants to add the agent to a thread and start chatting. If yes, create a thread with members and hand off to the `chat` skill.
+
+### User needs help creating or editing the config files first
+
+Route to the `agent_authoring` skill before deploying. That skill owns:
+- `AgentTemplate` and Script config creation
+- `archastro configs sample`
+- `archastro configs script-reference`
+- routine scheduling shape
+- env-var scope guidance
+
+### User wants to add an agent to a thread
+
+1. **If no thread exists**, create one:
+   ```
+   archastro create thread --title "..." --user <user-id>
+   ```
+
+2. **Add the agent as a member**:
+   ```
+   archastro create threadmember --thread <thread-id> --agent-id <agent-id>
+   ```
+
+3. **Add any other participants**:
+   ```
+   archastro create threadmember --thread <thread-id> --user-id <user-id>
+   ```
+
+4. **Confirm** the thread is ready and offer to send the first message.
+
+### User asks about existing agents
+
+List agents and present them:
+```
+archastro list agents
+```
+
+Summarize what's deployed and offer to deploy a new one or add an existing one to a thread.
+
+## Recovery Rules
+
+- If `archastro deploy agent` fails with a validation-style error, inspect the exact CLI output first. Do not immediately fall back to lower-level provisioning commands.
+- If the problem appears to be in the config files, route to `agent_authoring`.
+- If a script-related validation error appears, use:
+  ```
+  archastro configs script-reference
+  archastro configs sample Script
+  ```
+  Do not invent script syntax from memory.
+- Prefer human-readable `config_ref` names that match deployed config lookup keys. Do not rewrite refs to raw `cfg_...` IDs unless explicitly debugging a broken environment.
+
+## Response Rules
+
+- Do not inspect or edit credential files directly — use the CLI only.
+- Do not ask the user to pick a subcommand — infer the action from their message.
+- If the CLI reports an auth or app error, run `archastro auth login` or suggest `--app <id>`.
+- Keep responses concise — state the outcome, not the process.

--- a/plugins/archastro/skills/auth/SKILL.md
+++ b/plugins/archastro/skills/auth/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: auth
+description: Use when the user wants to authenticate with or log in to the ArchAstro developer platform, or when the CLI reports an authentication error. Trigger phrases include "authenticate archastro", "archastro auth login", "log in to archastro", "archastro not authenticated", "archastro auth status", "sign in to archastro".
+allowed-tools: ["Bash(archastro:*)"]
+---
+
+# ArchAstro CLI Authentication
+
+Authenticate the user with the ArchAstro developer platform via browser-based login. Defaults to org mode (Agent Network).
+
+## Instructions
+
+1. **Read the compatibility contract first**:
+   - Use `plugin-compatibility.json`.
+   - For this command, prefer `plugins.archastro.minimumCliVersion` and fall back to the top-level `minimumCliVersion`.
+   - Treat that resolved value as the minimum supported CLI version for every check below.
+
+2. **Check the installed CLI version first**:
+   ```
+   archastro --version
+   ```
+   If the command is missing, or the version is older than the resolved minimum version, instruct the user to install or upgrade `archastro`.
+
+3. **Check if already authenticated**:
+   ```
+   archastro auth status
+   ```
+   If the user is already authenticated, show their status and ask if they want to re-authenticate.
+
+4. **Determine the auth mode**:
+
+   The default is **org mode** (Agent Network). Only use developer mode if the user explicitly asks to log in as a developer or app builder.
+
+   - **Org mode** (default): For users within an organization. No app slug needed — defaults to Agent Network.
+   - **Developer mode**: For building and managing apps on the platform. Requires the `--dev` flag.
+
+5. **Reset any stale settings overrides** that may point to localhost:
+   ```
+   archastro settings reset
+   ```
+   This ensures the CLI uses the production URLs.
+
+6. **Start the login flow**:
+
+   **Org mode (default):**
+   ```
+   archastro auth login
+   ```
+
+   **Org mode for a specific app** (if the user specifies a different app slug):
+   ```
+   archastro auth login --app <app-slug>
+   ```
+
+   **Developer mode** (only if explicitly requested):
+   ```
+   archastro auth login --dev
+   ```
+
+   Use `run_in_background: true` so the browser-based auth flow runs while you remain responsive.
+
+   The CLI will open the user's browser to https://developers.archastro.ai for authentication and print a URL in case the browser doesn't open automatically.
+
+7. **Tell the user** the auth flow is running and they should complete login in their browser. Let them know you're available to keep working on other things while waiting.
+
+8. **When the user says they've logged in** (or you're ready to check), wait for the command to finish and then re-check status.
+
+9. **On success**, confirm authentication succeeded and show their status:
+   ```
+   archastro auth status
+   ```
+   For org mode, verify the output shows `Auth mode: org` and the correct app/org name.
+
+10. **On failure**, show the error and suggest:
+    - Check their internet connection
+    - Try `archastro settings reset` if URLs look wrong
+    - `no-access` error means the user doesn't have org access — verify with an org admin for an invite
+    - Try again with `archastro auth login`

--- a/plugins/archastro/skills/chat/SKILL.md
+++ b/plugins/archastro/skills/chat/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: chat
+description: Use when the user wants to send a message to an ArchAstro agent, ask an agent a question, view a thread conversation, check for agent responses, or interact with an agent. Trigger phrases include "send a message", "ask the agent", "what did the agent say", "show the conversation", "check the thread", "talk to the agent", "message the agent", "create a session".
+allowed-tools: ["Bash(archastro:*)"]
+---
+
+# ArchAstro Agent Chat
+
+Send messages to agents and view their responses.
+
+This skill assumes the ArchAstro CLI is already installed and authenticated. Install or upgrade `archastro` if missing, and run `archastro auth login` if not authenticated.
+
+## Always Start with State
+
+Every invocation must begin by understanding the current context. Determine:
+
+1. Does the user want a quick one-off question (use agent session) or an ongoing conversation (use thread)?
+2. Do they have an existing session or thread, or need a new one?
+
+## Two Interaction Models
+
+### Agent Sessions (recommended for most use cases)
+
+Direct 1:1 conversation with an agent. Use `--wait` to stream the response via SSE.
+
+**One-shot question** — put the question in `--instructions` and use `--wait`:
+```
+archastro create agentsession --agent <agent-id> --instructions "What are the open issues?" --wait
+```
+The agent processes the instructions as its task. `--wait` streams updates until completion.
+
+**Multi-turn conversation** — create session, send messages with `exec --wait`:
+```
+archastro create agentsession --agent <agent-id> --thread-id <thread-id> --instructions "Respond to messages"
+archastro exec agentsession <session-id> -m "What are the open issues?" --wait
+```
+`exec --wait` blocks and streams the agent's response in real-time. Without `--wait`, exec returns immediately after sending.
+
+### Threads (for multi-participant conversations)
+
+Threads support multiple users and agents. Use when you need ongoing conversation context or multiple participants.
+
+## Routing
+
+### CLI not installed or too old
+
+Before any chat work, verify the CLI:
+
+- Read `plugin-compatibility.json` from the plugin root.
+- Prefer `plugins.archastro.minimumCliVersion`, fall back to the top-level `minimumCliVersion`.
+- Run `archastro --version`. If missing or older than the resolved minimum, instruct the user to install or upgrade `archastro`.
+- If authentication or app selection is missing, instruct the user to run `archastro auth login`.
+
+### User wants to ask an agent a question
+
+**Preferred: agent session with `--wait`**
+
+```
+archastro create agentsession --agent <agent-id> --instructions "<question>" --wait
+```
+This creates the session, processes the question, and streams the result — all in one command.
+
+For longer timeouts:
+```
+archastro create agentsession --agent <agent-id> --instructions "<question>" --wait --timeout 300
+```
+
+**Alternative: exec with `--wait`**
+
+If you need to send follow-up messages to an existing session:
+```
+archastro exec agentsession <session-id> -m "<question>" --wait
+```
+
+**Without `--wait`** (fire-and-forget):
+```
+archastro create agentsession --agent <agent-id> --instructions "<question>"
+archastro describe agentsession <session-id> --follow
+```
+Use `describe --follow` to stream updates on a session created without `--wait`.
+
+### User wants to send a thread message
+
+1. **Determine the sender ID**:
+
+   **Org mode**: Get the user's ID from `archastro auth status`.
+
+   **Developer mode**: Look up thread members:
+   ```
+   archastro list threadmembers --thread <thread-id>
+   ```
+
+2. **Send the message and wait for the response**:
+   ```
+   archastro create threadmessage --thread <thread-id> --user-id <user-id> --content "..." \
+     --wait --wait-timeout 300
+   ```
+
+3. **When the response arrives**, read the full content:
+   ```
+   archastro list threadmessages --thread <thread-id> --full
+   ```
+
+### User wants to view a conversation
+
+```
+archastro list threadmessages --thread <thread-id> --full
+```
+Always use `--full` — the default table view truncates content.
+
+### User needs a new thread
+
+1. Create the thread:
+   ```
+   archastro create thread --title "..." --user <user-id>
+   ```
+
+2. Add members:
+   ```
+   archastro create threadmember --thread <thread-id> --agent-id <agent-id>
+   ```
+
+## Response Rules
+
+- Do not inspect or edit credential files directly — use the CLI only.
+- Do not ask the user to pick a subcommand — infer the action from their message.
+- If the CLI reports an auth or app error, run `archastro auth login` or suggest `--app <id>`.
+- Keep responses concise — state the outcome, not the process.
+- **Prefer agent sessions over threads** for simple question/answer interactions.
+- **Always use `--wait`** when the user expects to see the agent's response.

--- a/plugins/archastro/skills/impersonate/SKILL.md
+++ b/plugins/archastro/skills/impersonate/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: impersonate
+description: Use when the user wants to impersonate an ArchAstro agent, asks about the active impersonation state, wants to refresh or stop impersonation, or refers to working as a specific ArchAstro agent inside Codex. Trigger phrases include "impersonate agent", "act as this agent", "be this agent", "start impersonation", "sync impersonation", "stop impersonation", "what agent am I impersonating", and "use the active agent identity".
+allowed-tools: ["Bash(archastro:*)"]
+---
+
+# ArchAstro Agent Impersonation
+
+Manage ArchAstro agent impersonation and keep the Codex session aligned with the active identity.
+
+This skill assumes the ArchAstro CLI is already installed and authenticated. Install or upgrade `archastro` if missing, and run `archastro auth login` if not authenticated.
+
+## Always Start with State
+
+Every invocation of this skill must begin by checking the current impersonation state. Do not ask the user what action to take — determine it from state and intent.
+
+```
+archastro impersonate status --json
+```
+
+Then route based on the combination of current state and user intent.
+
+## Routing
+
+### CLI not installed or too old
+
+Before any impersonation work, verify the CLI:
+
+- Read `plugin-compatibility.json` from the plugin root.
+- Prefer `plugins.archastro.minimumCliVersion`, fall back to the top-level `minimumCliVersion`.
+- Run `archastro --version`. If missing or older than the resolved minimum, instruct the user to install or upgrade `archastro`.
+- If authentication or app selection is missing, instruct the user to run `archastro auth login`.
+
+### Inactive + user wants to start
+
+```
+archastro impersonate start <agent-or-flags>
+```
+
+Then:
+
+```
+archastro impersonate status --json
+```
+
+Read the `identity_file` path from the returned state. Open and read that file. Adopt the identity for the current Codex session while retaining your normal capabilities.
+
+After adoption, check `state.skills`. If the agent has linked skills, tell the user what's available and offer to install them:
+
+```
+archastro impersonate list skills --json
+```
+
+### Active + user asks about status (or no specific intent)
+
+Summarize the current state from the JSON already fetched:
+
+- Agent name and ID
+- App ID
+- Tool count and skill count
+- Loaded (installed) skills and their invocations
+- Timestamps
+
+If the identity file has not been read in this session yet, read it and adopt the identity.
+
+### Active + user wants to sync/refresh
+
+```
+archastro impersonate sync
+```
+
+Then:
+
+```
+archastro impersonate status --json
+```
+
+Re-read the `identity_file` and re-adopt the refreshed identity. Report what changed (new/removed tools or skills).
+
+### Active + user wants to stop
+
+```
+archastro impersonate stop
+```
+
+Drop the impersonated identity from the current session. Confirm that local state was removed.
+
+### Active + user asks about skills
+
+List available skills:
+
+```
+archastro impersonate list skills --json
+```
+
+Show what's available vs what's already installed (from `state.loaded_skills`).
+
+To install a skill:
+
+```
+archastro impersonate install skill <skill-id-or-slug>
+```
+
+After install, report the invocation command (e.g., `/<skill-name>`) so the user knows how to use it.
+
+For Codex or OpenCode targets:
+
+```
+archastro impersonate install skill <id> --harness codex --install-scope project
+```
+
+### Inactive + user asks about status
+
+Report that no impersonation is active and offer to start one.
+
+## Adopting the Identity
+
+When you read the identity file, you must **become that agent** for the rest of the session. This is not cosmetic — it changes how you behave:
+
+- **Personality and tone.** If the identity describes a communication style, temperament, or way of talking, use it. Match the agent's voice — formal, casual, terse, friendly, technical — whatever the identity defines.
+- **Background and expertise.** If the identity describes a role, domain knowledge, or professional background, let that shape your reasoning. Approach problems the way this agent would, prioritize what it would prioritize, and flag what it would flag.
+- **Scope and boundaries.** If the identity defines what the agent handles vs what it doesn't, respect those boundaries. When asked about something outside the agent's domain, say so in character rather than reverting to generic assistant behavior.
+- **Stay in character across turns.** Do not drop the persona between messages. Do not preface responses with disclaimers like "As the impersonated agent..." — just be the agent.
+- **Keep your capabilities.** You still have full tool access (file read/write, bash, search, etc.). The identity shapes how and when you use them, not whether you can.
+
+After `stop`, fully drop the persona and return to your normal behavior.
+
+## Session Integration
+
+- After `start` or `sync`, always read the identity file and adopt it as described above
+- After `stop`, always drop the identity and revert to normal behavior
+- When showing status, always include loaded skill invocations so the user knows what commands are available
+- When skills are available but not installed, proactively mention them
+
+## Limitations
+
+- **Integration tools do not resolve during impersonation.** Tools backed by server-side integrations (GitHub, Slack, Gmail, etc.) require OAuth credentials that cannot be exported locally. Only builtin tools and custom script tools are available.
+- For agents that rely primarily on integrations, use agent sessions (`archastro create agentsession --agent <id> --wait`) instead of impersonation.
+
+## Response Rules
+
+- Do not inspect or edit credential files directly — use the CLI only.
+- Do not ask the user to pick a subcommand — infer the action from their message and the current state.
+- If the CLI reports an auth or app error, run `archastro auth login` or suggest `--app <id>`.
+- Keep responses concise — state the outcome, not the process.

--- a/plugins/archastro/skills/install/SKILL.md
+++ b/plugins/archastro/skills/install/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: install
+description: Use when the user wants to install, upgrade, or bootstrap the ArchAstro CLI. Trigger phrases include "install archastro", "install the archastro CLI", "set up archastro", "upgrade archastro", "archastro not found", "archastro command not found", "install the CLI", "get archastro running".
+allowed-tools: ["Bash(archastro:*)", "Bash(brew:*)", "Bash(curl:*)", "Bash(bash:*)", "Bash(sh:*)", "Bash(pwsh:*)", "Bash(powershell:*)"]
+---
+
+# Install ArchAstro CLI
+
+Install or upgrade the public `archastro` binary from Homebrew or GitHub Releases.
+
+## Instructions
+
+1. **Read the compatibility contract first**:
+   - Use `plugin-compatibility.json`.
+   - For this command, prefer `plugins.archastro.minimumCliVersion` and fall back to the top-level `minimumCliVersion`.
+   - Treat that resolved value as the minimum supported CLI version for every check below.
+
+2. **Check whether the CLI is already installed**:
+   ```
+   archastro --version
+   ```
+   If this succeeds, record the version.
+
+3. **If the CLI is present and meets the resolved minimum version**, confirm the version and stop unless the user explicitly asked to upgrade.
+
+4. **If the CLI is missing or older than the resolved minimum version**, install it using the public distribution path:
+   - On macOS, if Homebrew is available:
+     ```
+     brew install ArchAstro/tools/archastro
+     ```
+     If the formula is already installed, run:
+     ```
+     brew upgrade ArchAstro/tools/archastro
+     ```
+   - On Linux or macOS without Homebrew:
+     ```
+     curl -fsSL https://raw.githubusercontent.com/ArchAstro/archastro-cli/main/install.sh | bash
+     ```
+   - On Windows PowerShell:
+     ```powershell
+     irm https://raw.githubusercontent.com/ArchAstro/archastro-cli/main/install.ps1 | iex
+     ```
+
+5. **Verify installation**:
+   ```
+   archastro --version
+   ```
+   Confirm that the version now meets the resolved minimum version.
+
+6. **On success**, tell the user the CLI is ready and suggest they run `archastro auth login` to authenticate.
+
+7. **On failure**, help troubleshoot the public install path:
+   - missing `brew` is expected on Linux and some macOS setups; fall back to `install.sh`
+   - `Permission denied` usually means they need `--install-dir` or a user-writable target directory
+   - `command not found: archastro` after install usually means the install directory is not on `PATH`
+   - release download failures usually mean the target release asset has not been published yet

--- a/scripts/generate-plugin-content.py
+++ b/scripts/generate-plugin-content.py
@@ -1,0 +1,421 @@
+#!/usr/bin/env python3
+"""
+Generate Claude Code and Codex plugin content from canonical sources in sources/.
+
+One source file per concept in sources/<name>.md. Each source declares its
+output targets (claude-skill, claude-command, codex-skill) via the `targets:`
+frontmatter field. The script applies harness-specific substitutions and
+conditional blocks, then writes to the declared output paths.
+
+USAGE
+    python3 scripts/generate-plugin-content.py           # write outputs
+    python3 scripts/generate-plugin-content.py --check   # diff against committed, exit 1 if different
+
+SOURCE FILE FORMAT
+    ---
+    targets:
+      claude-skill: <dirname>      # → .claude-plugins/archastro/skills/<dirname>/SKILL.md
+      claude-command: <filename>   # → .claude-plugins/archastro/commands/<filename>
+      codex-skill: <dirname>       # → plugins/archastro/skills/<dirname>/SKILL.md
+    skill:                         # frontmatter used for any skill target
+      name: <name>                 # must match <dirname>
+      description: <description>   # natural-language trigger phrases
+      allowed-tools: [...]
+    command:                       # frontmatter used for claude-command targets
+      description: <description>
+      allowed-tools: [...]
+    ---
+
+    # Body
+
+    Body content with {{SUBSTITUTION}} placeholders and conditional blocks.
+
+SUBSTITUTIONS (resolved per target harness)
+    {{HARNESS_NAME}}       "Claude Code" | "Codex"
+    {{SESSION}}            "Claude Code session" | "Codex session"
+    {{ASSUME_INSTALLED}}   harness-specific CLI install reminder paragraph
+    {{INSTALL_ROUTE}}      "direct the user to `/archastro:install`" |
+                           "instruct the user to install or upgrade `archastro`"
+    {{AUTH_ROUTE}}         "direct the user to `/archastro:auth`" |
+                           "instruct the user to run `archastro auth login`"
+    {{AUTH_ROUTE_SHORT}}   "route to `/archastro:auth`" | "run `archastro auth login`"
+
+CONDITIONAL BLOCKS (emit only for matching targets)
+    {{#SKILL}} ... {{/SKILL}}                  any skill target (claude or codex)
+    {{#CLAUDE_COMMAND}} ... {{/CLAUDE_COMMAND}} only claude-command targets
+
+    Limitation: conditional blocks CANNOT nest. The non-greedy regex plus
+    backreferenced close-tag means a pattern like
+    `{{#A}}before {{#B}}inner{{/B}} after{{/A}}` would treat the outer `A`
+    block as matching everything through `{{/A}}`, and the inner `{{#B}}`
+    marker would leak into the substituted body as literal text. The
+    generator detects unbalanced open/close marker counts and raises at
+    generate time rather than silently producing wrong output.
+
+DESIGN NOTE: ASYMMETRY BETWEEN INSTALL/AUTH AND OTHER CONCEPTS
+    `install.md` and `auth.md` generate a claude-command + codex-skill, but
+    intentionally do NOT generate a claude-skill.
+
+    Why: install and auth are one-shot bootstrap actions. In Claude Code they
+    are discovered via `/` autocomplete — a slash command is the right UX.
+    Adding a claude-skill with the same name would create a naming collision
+    with the claude-command in the Skill tool's dispatch table.
+
+    In Codex there is no slash command concept (verified in
+    https://developers.openai.com/codex/plugins/build), so skills are the only
+    way to reach install/auth content via natural language. Codex gets a skill
+    with trigger phrases; Claude Code gets a command and relies on autocomplete
+    discovery.
+
+    Impersonate is different: it has subcommands (start/status/sync/stop) and
+    benefits from both explicit invocation (slash command) and conversational
+    triggering. It generates claude-skill + claude-command + codex-skill.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SOURCES_DIR = REPO_ROOT / "sources"
+CLAUDE_PLUGIN_ROOT = REPO_ROOT / ".claude-plugins" / "archastro"
+CODEX_PLUGIN_ROOT = REPO_ROOT / "plugins" / "archastro"
+
+
+TargetType = Literal["claude-skill", "claude-command", "codex-skill"]
+Harness = Literal["claude", "codex"]
+
+
+# Per-harness substitution maps. Keys are placeholders that appear in source
+# bodies and frontmatter; values are the harness-specific rendered string.
+SUBSTITUTIONS: dict[Harness, dict[str, str]] = {
+    "claude": {
+        "{{HARNESS_NAME}}": "Claude Code",
+        "{{SESSION}}": "Claude Code session",
+        "{{ASSUME_INSTALLED}}": (
+            "Use the `/archastro:install` and `/archastro:auth` commands in "
+            "this same plugin instead of trying to install or authenticate the "
+            "CLI manually inside this skill."
+        ),
+        "{{INSTALL_ROUTE}}": "direct the user to `/archastro:install`",
+        "{{AUTH_ROUTE}}": "direct the user to `/archastro:auth`",
+        "{{AUTH_ROUTE_SHORT}}": "route to `/archastro:auth`",
+    },
+    "codex": {
+        "{{HARNESS_NAME}}": "Codex",
+        "{{SESSION}}": "Codex session",
+        "{{ASSUME_INSTALLED}}": (
+            "Install or upgrade `archastro` if missing, and run "
+            "`archastro auth login` if not authenticated."
+        ),
+        "{{INSTALL_ROUTE}}": "instruct the user to install or upgrade `archastro`",
+        "{{AUTH_ROUTE}}": "instruct the user to run `archastro auth login`",
+        "{{AUTH_ROUTE_SHORT}}": "run `archastro auth login`",
+    },
+}
+
+
+# Conditional block markers. A block is emitted only if its key is in the
+# active set for the current target.
+#   - claude-skill  → {"SKILL", "CLAUDE_SKILL"}
+#   - codex-skill   → {"SKILL", "CODEX_SKILL"}
+#   - claude-command → {"CLAUDE_COMMAND"}
+CONDITIONAL_SETS: dict[TargetType, set[str]] = {
+    "claude-skill": {"SKILL", "CLAUDE_SKILL"},
+    "codex-skill": {"SKILL", "CODEX_SKILL"},
+    "claude-command": {"CLAUDE_COMMAND"},
+}
+
+CONDITIONAL_RE = re.compile(
+    r"\{\{#(?P<key>[A-Z_]+)\}\}(?P<body>.*?)\{\{/(?P=key)\}\}",
+    flags=re.DOTALL,
+)
+
+
+@dataclass
+class Source:
+    path: Path
+    targets: dict[str, str]  # target_type → dirname or filename
+    skill_frontmatter: dict | None
+    command_frontmatter: dict | None
+    body: str
+
+
+def split_frontmatter(text: str) -> tuple[dict, str]:
+    """Return (frontmatter_dict, body). Raises ValueError if missing."""
+    if not text.startswith("---\n"):
+        raise ValueError("no frontmatter block")
+    end = text.find("\n---\n", 4)
+    if end == -1:
+        raise ValueError("unterminated frontmatter block")
+    fm_raw = text[4:end]
+    body = text[end + len("\n---\n"):]
+    fm = yaml.safe_load(fm_raw)
+    if not isinstance(fm, dict):
+        raise ValueError("frontmatter is not a mapping")
+    return fm, body
+
+
+def load_source(path: Path) -> Source:
+    text = path.read_text(encoding="utf-8")
+    fm, body = split_frontmatter(text)
+    targets = fm.get("targets") or {}
+    if not targets or not isinstance(targets, dict):
+        raise ValueError(f"{path}: missing or empty `targets` block")
+    for t in targets:
+        if t not in ("claude-skill", "claude-command", "codex-skill"):
+            raise ValueError(f"{path}: unknown target type {t!r}")
+    return Source(
+        path=path,
+        targets=targets,
+        skill_frontmatter=fm.get("skill"),
+        command_frontmatter=fm.get("command"),
+        body=body,
+    )
+
+
+def apply_substitutions(text: str, harness: Harness) -> str:
+    subs = SUBSTITUTIONS[harness]
+    for placeholder, value in subs.items():
+        text = text.replace(placeholder, value)
+    return text
+
+
+CONDITIONAL_OPEN_RE = re.compile(r"\{\{#[A-Z_]+\}\}")
+CONDITIONAL_CLOSE_RE = re.compile(r"\{\{/[A-Z_]+\}\}")
+
+
+def apply_conditionals(text: str, target: TargetType) -> str:
+    """Expand {{#KEY}}...{{/KEY}} blocks, keeping only those matching target.
+
+    Conditional blocks cannot nest. The non-greedy regex with a backreferenced
+    close tag would mishandle nesting and silently leak inner markers into the
+    output, so we detect unbalanced open/close marker counts up front and raise.
+
+    A post-substitution check catches key-swapped pairs (e.g.
+    {{#SKILL}}...{{/CLAUDE_COMMAND}}) where global counts balance but the
+    backreference doesn't match, leaving raw markers in the output.
+    """
+    open_count = len(CONDITIONAL_OPEN_RE.findall(text))
+    close_count = len(CONDITIONAL_CLOSE_RE.findall(text))
+    if open_count != close_count:
+        raise ValueError(
+            f"unbalanced conditional markers in source: {open_count} open, "
+            f"{close_count} close. Conditional blocks must be paired and "
+            f"cannot nest."
+        )
+
+    active = CONDITIONAL_SETS[target]
+
+    def replace(match: re.Match) -> str:
+        key = match.group("key")
+        inner = match.group("body")
+        return inner if key in active else ""
+
+    result = CONDITIONAL_RE.sub(replace, text)
+
+    # Post-check: markers surviving substitution indicate mismatched keys
+    # (e.g. {{#SKILL}}...{{/CLAUDE_COMMAND}} — balanced globally but the
+    # backreference can't pair them).
+    remaining = CONDITIONAL_OPEN_RE.findall(result) + CONDITIONAL_CLOSE_RE.findall(result)
+    if remaining:
+        raise ValueError(
+            f"conditional markers survived substitution (likely mismatched "
+            f"keys): {remaining}"
+        )
+
+    return result
+
+
+def format_frontmatter(fm: dict) -> str:
+    """
+    Render frontmatter dict as a YAML block matching the Claude Code plugin
+    convention: each key on its own line, string values as plain scalars (no
+    quoting), lists as flow-style with double-quoted elements.
+
+    This hand-rolled rendering is intentional — PyYAML's default dumper wraps
+    long strings and escapes Unicode, producing output that differs from the
+    committed files. The Claude Code and Codex harnesses both accept plain
+    scalars for the descriptions we write, so no quoting is needed.
+
+    The output is round-trip validated: the rendered block is re-parsed by
+    yaml.safe_load and must equal the input dict. This catches any future
+    description that contains YAML-hostile characters (leading `-`, ` : `,
+    ` #`, etc.) at generate time, instead of letting the harness silently
+    fail to parse the skill.
+    """
+    lines = ["---"]
+    for key, value in fm.items():
+        if isinstance(value, list):
+            # Flow-style list with double-quoted string elements
+            items = ", ".join(f'"{item}"' for item in value)
+            lines.append(f"{key}: [{items}]")
+        elif isinstance(value, str):
+            # Plain scalar — no quoting. Validated by round-trip parse below.
+            lines.append(f"{key}: {value}")
+        else:
+            lines.append(f"{key}: {value}")
+    lines.append("---")
+    rendered = "\n".join(lines) + "\n"
+
+    # Round-trip validation: re-parse our hand-rolled YAML and assert it
+    # matches the input dict. Any divergence means a frontmatter value
+    # contained a YAML-hostile pattern that we silently corrupted.
+    yaml_body = "\n".join(lines[1:-1])
+    try:
+        reparsed = yaml.safe_load(yaml_body)
+    except yaml.YAMLError as e:
+        raise ValueError(
+            f"frontmatter round-trip failed: hand-rolled YAML did not parse. "
+            f"A frontmatter value likely contains a YAML-hostile character "
+            f"(leading `-`, ` : `, ` #`, unbalanced `'` or `\"`, etc.).\n"
+            f"  input: {fm!r}\n  parser error: {e}"
+        ) from e
+    if reparsed != fm:
+        raise ValueError(
+            f"frontmatter round-trip failed: rendered YAML parses to a "
+            f"different dict than the input. A frontmatter value contains "
+            f"a character that changes meaning under YAML parsing.\n"
+            f"  input:    {fm!r}\n  reparsed: {reparsed!r}"
+        )
+
+    return rendered
+
+
+def render_target(source: Source, target_type: TargetType) -> tuple[Path, str]:
+    """Render one (source, target) pair and return (output_path, content)."""
+    target_value = source.targets[target_type]
+
+    # Determine harness
+    harness: Harness = "codex" if target_type == "codex-skill" else "claude"
+
+    # Resolve output path
+    if target_type == "claude-skill":
+        output_path = CLAUDE_PLUGIN_ROOT / "skills" / target_value / "SKILL.md"
+    elif target_type == "codex-skill":
+        output_path = CODEX_PLUGIN_ROOT / "skills" / target_value / "SKILL.md"
+    elif target_type == "claude-command":
+        output_path = CLAUDE_PLUGIN_ROOT / "commands" / target_value
+    else:
+        raise ValueError(f"unknown target type: {target_type}")
+
+    # Pick frontmatter block based on target type
+    if target_type in ("claude-skill", "codex-skill"):
+        if not source.skill_frontmatter:
+            raise ValueError(f"{source.path}: {target_type} requires `skill:` frontmatter block")
+        fm = dict(source.skill_frontmatter)  # copy
+    else:  # claude-command
+        if not source.command_frontmatter:
+            raise ValueError(f"{source.path}: {target_type} requires `command:` frontmatter block")
+        fm = dict(source.command_frontmatter)
+
+    # Apply substitutions to frontmatter string values
+    for key, value in list(fm.items()):
+        if isinstance(value, str):
+            fm[key] = apply_substitutions(value, harness)
+
+    # Render body: conditionals first, then substitutions.
+    # Normalize leading blank lines — the source format allows whitespace
+    # between the closing frontmatter fence and the body, but the output
+    # should have exactly one blank line between fence and first body line.
+    body = apply_conditionals(source.body, target_type)
+    body = apply_substitutions(body, harness)
+    body = body.lstrip("\n")
+
+    # Stitch frontmatter + blank line + body
+    content = format_frontmatter(fm) + "\n" + body
+
+    return output_path, content
+
+
+def render_all() -> dict[Path, str]:
+    """Render every source to every declared target. Return {path: content}."""
+    if not SOURCES_DIR.exists():
+        raise FileNotFoundError(f"sources dir not found: {SOURCES_DIR}")
+
+    outputs: dict[Path, str] = {}
+    for source_path in sorted(SOURCES_DIR.glob("*.md")):
+        source = load_source(source_path)
+        for target_type in source.targets:
+            output_path, content = render_target(source, target_type)  # type: ignore[arg-type]
+            if output_path in outputs:
+                raise ValueError(
+                    f"output collision at {output_path} from {source_path} "
+                    f"and a previous source"
+                )
+            outputs[output_path] = content
+    return outputs
+
+
+def write_outputs(outputs: dict[Path, str]) -> int:
+    """Write outputs to disk. Return number of files written."""
+    written = 0
+    for path, content in outputs.items():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        existing = path.read_text(encoding="utf-8") if path.exists() else None
+        if existing != content:
+            path.write_text(content, encoding="utf-8")
+            written += 1
+    return written
+
+
+def check_outputs(outputs: dict[Path, str]) -> list[Path]:
+    """Compare generator output to committed files. Return list of paths that differ."""
+    diffs: list[Path] = []
+    for path, content in outputs.items():
+        if not path.exists():
+            diffs.append(path)
+            continue
+        if path.read_text(encoding="utf-8") != content:
+            diffs.append(path)
+    return diffs
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Diff generator output against committed files; exit 1 if different",
+    )
+    args = parser.parse_args()
+
+    try:
+        outputs = render_all()
+    except (ValueError, FileNotFoundError) as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        return 2
+
+    if args.check:
+        diffs = check_outputs(outputs)
+        if diffs:
+            print(
+                f"FAIL: {len(diffs)} file(s) are out of sync with sources/. "
+                "Run `python3 scripts/generate-plugin-content.py` and commit the result.",
+                file=sys.stderr,
+            )
+            for p in diffs:
+                print(f"  {p.relative_to(REPO_ROOT)}", file=sys.stderr)
+            return 1
+        print(f"OK: {len(outputs)} file(s) in sync with sources/.")
+        return 0
+
+    written = write_outputs(outputs)
+    print(f"Wrote {written}/{len(outputs)} file(s) (others already up-to-date).")
+    if written > 0:
+        print(
+            "NOTE: content changed — remember to bump the plugin version in "
+            "all three manifest files or the plugin caches will not refresh."
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/sources/agent_authoring.md
+++ b/sources/agent_authoring.md
@@ -1,0 +1,126 @@
+---
+targets:
+  claude-skill: agent_authoring
+  codex-skill: agent_authoring
+skill:
+  name: agent_authoring
+  description: Use when the user wants to create or edit an ArchAstro agent's config files before deployment, including AgentTemplate files, Script configs, custom tools, routines, and environment setup. Trigger phrases include "build this agent", "write the template", "create the scripts", "set up the routines", "author this agent config".
+  allowed-tools: ['Bash(archastro:*)']
+---
+
+
+# ArchAstro Agent Authoring
+
+Create or update the config files for a config-driven ArchAstro agent before deployment.
+
+This skill assumes the ArchAstro CLI is already installed and authenticated. {{ASSUME_INSTALLED}}
+
+## Always Start with State
+
+Every invocation must begin by understanding the current project state:
+
+```
+archastro auth status
+```
+
+If the user is in a repo, inspect whether a `configs/` directory already exists and whether the agent already has Script or AgentTemplate files.
+
+## Routing
+
+### CLI not installed or too old
+
+Before any authoring work, verify the CLI:
+
+- Read `plugin-compatibility.json` from the plugin root.
+- Prefer `plugins.archastro.minimumCliVersion`, fall back to the top-level `minimumCliVersion`.
+- Run `archastro --version`. If missing or older than the resolved minimum, {{INSTALL_ROUTE}}.
+- If authentication or app selection is missing, {{AUTH_ROUTE}}.
+
+### User wants to author or modify agent configs
+
+1. **Start from CLI-backed templates, not memory**:
+   - For new config objects, use:
+     ```
+     archastro configs sample <Kind>
+     ```
+   - For Script configs, always use:
+     ```
+     archastro configs script-reference
+     archastro configs sample Script
+     ```
+     The script reference is the live source of truth. Do not invent or paraphrase the language from memory.
+
+2. **Use the standard config-driven model**:
+   - Script logic lives in `kind: Script` configs.
+   - Agent behavior lives in an `AgentTemplate`.
+   - Custom tools should use `kind: custom`, `handler_type: script`, and `config_ref` pointing at Script configs.
+   - When creating configs outside a project directory, use `-f` to read from a file:
+     ```
+     archastro create config -k AgentTemplate -f configs/agents/my-agent.yaml
+     ```
+
+3. **Validate early**:
+   ```
+   archastro configs validate
+   ```
+   Run validation before deploy whenever the user changes Script or template files.
+
+4. **Deploy through the normal flow after authoring**:
+   - If the agent has Script configs or other supporting files, sync them first:
+     ```
+     archastro configs deploy
+     ```
+     This pushes local config files (Scripts, templates) but does not create agents.
+     Skip this step if the agent only has a single AgentTemplate file — `deploy agent` handles its own config upload.
+   - Then provision the agent from its template:
+     ```
+     archastro deploy agent <yaml-file>
+     ```
+     This uploads the template config and creates the agent with its routines, tools, and installations.
+   - **Important:** `configs deploy` and `deploy agent` are different commands.
+     Use `configs deploy` to sync a directory of config files; use `deploy agent` to create an agent from a template.
+
+## Authoring Rules
+
+### Script configs
+
+- Treat the script language as a functional expression language, not a general-purpose imperative language.
+- Use `archastro configs script-reference` for exact syntax and available namespaces.
+- If a script fails validation, prefer rewriting toward the sample/reference instead of trial-and-error improvisation.
+
+### Routine configs inside templates
+
+- Scheduled routines need both:
+  - `schedule: "<cron>"`
+  - `event_type: schedule.cron`
+- Do not put schedules under nested `event_config.schedule`.
+
+### Config references
+
+- Prefer human-readable `config_ref` values that match deployed config lookup keys.
+- Do not convert refs to raw `cfg_...` IDs unless explicitly debugging a broken environment.
+
+### Environment variables
+
+- For org users, prefer org-scoped environment variables when they are sufficient for the agent's needs.
+- Do not default users into app-scoped env-var flows unless the use case truly requires app scope.
+
+## Recovery Rules
+
+- If the user asks for a brand-new Script and the language shape is unclear, run `archastro configs script-reference` before drafting.
+- If validation fails, surface the exact failing field or syntax problem. Do not immediately switch to lower-level provisioning commands.
+- If the user asks to "just create the agent" while configs are still incomplete, finish authoring and validation first, then route to `agent_deploy`.
+
+## Command Conventions
+
+- Config management uses two patterns:
+  - **Noun-first** for workflow commands: `archastro configs deploy`, `archastro configs sync`, `archastro configs validate`
+  - **Verb-first** for CRUD: `archastro list configs`, `archastro describe config <id>`, `archastro create config`
+- Do not use `archastro configs list` or `archastro configs describe` — those are not valid. Use the verb-first form.
+
+## Response Rules
+
+- Do not inspect or edit credential files directly — use the CLI only.
+- Do not ask the user to pick raw subcommands when intent is clear.
+- Keep responses concise and operational.
+- Prefer the golden path over fallback commands.

--- a/sources/agent_deploy.md
+++ b/sources/agent_deploy.md
@@ -1,0 +1,122 @@
+---
+targets:
+  claude-skill: agent_deploy
+  codex-skill: agent_deploy
+skill:
+  name: agent_deploy
+  description: Use when the user wants to deploy an ArchAstro agent, turn a config-driven agent repo into a running agent, or get an existing agent running in a thread. Trigger phrases include "deploy agent", "deploy this agent", "set up an agent", "launch agent", "ship this agent", "get this agent running".
+  allowed-tools: ['Bash(archastro:*)']
+---
+
+
+# ArchAstro Agent Deployment
+
+Deploy an agent from a YAML template and get it running in a thread.
+
+This skill assumes the ArchAstro CLI is already installed and authenticated. {{ASSUME_INSTALLED}}
+
+## Always Start with State
+
+Every invocation must begin by understanding what already exists:
+
+```
+archastro auth status
+archastro list agents
+```
+
+If the user is working from a local repo, also inspect whether a `configs/` directory already exists. Determine whether they want to:
+- deploy a new config-driven agent,
+- redeploy an existing template,
+- or work with an existing running agent.
+
+## Routing
+
+### CLI not installed or too old
+
+Before any deployment work, verify the CLI:
+
+- Read `plugin-compatibility.json` from the plugin root.
+- Prefer `plugins.archastro.minimumCliVersion`, fall back to the top-level `minimumCliVersion`.
+- Run `archastro --version`. If missing or older than the resolved minimum, {{INSTALL_ROUTE}}.
+- If authentication or app selection is missing, {{AUTH_ROUTE}}.
+
+### User wants to deploy a new agent
+
+Use the config-driven golden path. Do not skip straight to `create agent`.
+
+1. **Deploy configs first**:
+   ```
+   archastro configs deploy
+   ```
+   This pushes Script and AgentTemplate configs to the server. For config-driven agents, this should happen before provisioning the agent itself.
+
+2. **Deploy the agent from the template file**:
+   ```
+   archastro deploy agent <yaml-file>
+   ```
+   This creates the full agent stack in one step: app config, agent record, routines, and installations. Note the agent ID (`agi_...`) from the output.
+
+   **Important:** Always use `deploy agent`, not `create agent`. The `create agent` command only creates the agent record without provisioning routines or installations.
+
+3. **Verify the deployment**:
+   ```
+   archastro list agents
+   ```
+
+4. **Offer next steps**: ask if the user wants to add the agent to a thread and start chatting. If yes, create a thread with members and hand off to the `chat` skill.
+
+### User needs help creating or editing the config files first
+
+Route to the `agent_authoring` skill before deploying. That skill owns:
+- `AgentTemplate` and Script config creation
+- `archastro configs sample`
+- `archastro configs script-reference`
+- routine scheduling shape
+- env-var scope guidance
+
+### User wants to add an agent to a thread
+
+1. **If no thread exists**, create one:
+   ```
+   archastro create thread --title "..." --user <user-id>
+   ```
+
+2. **Add the agent as a member**:
+   ```
+   archastro create threadmember --thread <thread-id> --agent-id <agent-id>
+   ```
+
+3. **Add any other participants**:
+   ```
+   archastro create threadmember --thread <thread-id> --user-id <user-id>
+   ```
+
+4. **Confirm** the thread is ready and offer to send the first message.
+
+### User asks about existing agents
+
+List agents and present them:
+```
+archastro list agents
+```
+
+Summarize what's deployed and offer to deploy a new one or add an existing one to a thread.
+
+## Recovery Rules
+
+- If `archastro deploy agent` fails with a validation-style error, inspect the exact CLI output first. Do not immediately fall back to lower-level provisioning commands.
+- If the problem appears to be in the config files, route to `agent_authoring`.
+- If a script-related validation error appears, use:
+  ```
+  archastro configs script-reference
+  archastro configs sample Script
+  ```
+  Do not invent script syntax from memory.
+- Prefer human-readable `config_ref` names that match deployed config lookup keys. Do not rewrite refs to raw `cfg_...` IDs unless explicitly debugging a broken environment.
+
+## Response Rules
+
+- Do not inspect or edit credential files directly — use the CLI only.
+- Do not ask the user to pick a subcommand — infer the action from their message.
+- If the CLI reports an auth or app error, {{AUTH_ROUTE_SHORT}} or suggest `--app <id>`.
+- Keep responses concise — state the outcome, not the process.

--- a/sources/auth.md
+++ b/sources/auth.md
@@ -1,0 +1,86 @@
+---
+targets:
+  claude-command: auth.md
+  codex-skill: auth
+skill:
+  name: auth
+  description: Use when the user wants to authenticate with or log in to the ArchAstro developer platform, or when the CLI reports an authentication error. Trigger phrases include "authenticate archastro", "archastro auth login", "log in to archastro", "archastro not authenticated", "archastro auth status", "sign in to archastro".
+  allowed-tools: ["Bash(archastro:*)"]
+command:
+  description: Authenticate with the ArchAstro developer platform (org mode by default)
+  allowed-tools: ["Bash(archastro:*)"]
+---
+
+
+# ArchAstro CLI Authentication
+
+Authenticate the user with the ArchAstro developer platform via browser-based login. Defaults to org mode (Agent Network).
+
+## Instructions
+
+1. **Read the compatibility contract first**:
+   - Use `plugin-compatibility.json`.
+   - For this command, prefer `plugins.archastro.minimumCliVersion` and fall back to the top-level `minimumCliVersion`.
+   - Treat that resolved value as the minimum supported CLI version for every check below.
+
+2. **Check the installed CLI version first**:
+   ```
+   archastro --version
+   ```
+   If the command is missing, or the version is older than the resolved minimum version, {{#CLAUDE_COMMAND}}tell the user to run `/archastro:install`{{/CLAUDE_COMMAND}}{{#SKILL}}instruct the user to install or upgrade `archastro`{{/SKILL}}.
+
+3. **Check if already authenticated**:
+   ```
+   archastro auth status
+   ```
+   If the user is already authenticated, show their status and ask if they want to re-authenticate.
+
+4. **Determine the auth mode**:
+
+   The default is **org mode** (Agent Network). Only use developer mode if the user explicitly asks to log in as a developer or app builder.
+
+   - **Org mode** (default): For users within an organization. No app slug needed — defaults to Agent Network.
+   - **Developer mode**: For building and managing apps on the platform. Requires the `--dev` flag.
+
+5. **Reset any stale settings overrides** that may point to localhost:
+   ```
+   archastro settings reset
+   ```
+   This ensures the CLI uses the production URLs.
+
+6. **Start the login flow**:
+
+   **Org mode (default):**
+   ```
+   archastro auth login
+   ```
+
+   **Org mode for a specific app** (if the user specifies a different app slug):
+   ```
+   archastro auth login --app <app-slug>
+   ```
+
+   **Developer mode** (only if explicitly requested):
+   ```
+   archastro auth login --dev
+   ```
+
+   Use `run_in_background: true` so the browser-based auth flow runs while you remain responsive.
+
+   The CLI will open the user's browser to https://developers.archastro.ai for authentication and print a URL in case the browser doesn't open automatically.
+
+7. **Tell the user** the auth flow is running and they should complete login in their browser. Let them know you're available to keep working on other things while waiting.
+
+8. **When the user says they've logged in** (or you're ready to check), wait for the command to finish and then re-check status.
+
+9. **On success**, confirm authentication succeeded and show their status:
+   ```
+   archastro auth status
+   ```
+   For org mode, verify the output shows `Auth mode: org` and the correct app/org name.
+
+10. **On failure**, show the error and suggest:
+    - Check their internet connection
+    - Try `archastro settings reset` if URLs look wrong
+    - `no-access` error means the user doesn't have org access — verify with an org admin for an invite
+    - Try again with `archastro auth login`

--- a/sources/chat.md
+++ b/sources/chat.md
@@ -1,0 +1,135 @@
+---
+targets:
+  claude-skill: chat
+  codex-skill: chat
+skill:
+  name: chat
+  description: Use when the user wants to send a message to an ArchAstro agent, ask an agent a question, view a thread conversation, check for agent responses, or interact with an agent. Trigger phrases include "send a message", "ask the agent", "what did the agent say", "show the conversation", "check the thread", "talk to the agent", "message the agent", "create a session".
+  allowed-tools: ['Bash(archastro:*)']
+---
+
+
+# ArchAstro Agent Chat
+
+Send messages to agents and view their responses.
+
+This skill assumes the ArchAstro CLI is already installed and authenticated. {{ASSUME_INSTALLED}}
+
+## Always Start with State
+
+Every invocation must begin by understanding the current context. Determine:
+
+1. Does the user want a quick one-off question (use agent session) or an ongoing conversation (use thread)?
+2. Do they have an existing session or thread, or need a new one?
+
+## Two Interaction Models
+
+### Agent Sessions (recommended for most use cases)
+
+Direct 1:1 conversation with an agent. Use `--wait` to stream the response via SSE.
+
+**One-shot question** — put the question in `--instructions` and use `--wait`:
+```
+archastro create agentsession --agent <agent-id> --instructions "What are the open issues?" --wait
+```
+The agent processes the instructions as its task. `--wait` streams updates until completion.
+
+**Multi-turn conversation** — create session, send messages with `exec --wait`:
+```
+archastro create agentsession --agent <agent-id> --thread-id <thread-id> --instructions "Respond to messages"
+archastro exec agentsession <session-id> -m "What are the open issues?" --wait
+```
+`exec --wait` blocks and streams the agent's response in real-time. Without `--wait`, exec returns immediately after sending.
+
+### Threads (for multi-participant conversations)
+
+Threads support multiple users and agents. Use when you need ongoing conversation context or multiple participants.
+
+## Routing
+
+### CLI not installed or too old
+
+Before any chat work, verify the CLI:
+
+- Read `plugin-compatibility.json` from the plugin root.
+- Prefer `plugins.archastro.minimumCliVersion`, fall back to the top-level `minimumCliVersion`.
+- Run `archastro --version`. If missing or older than the resolved minimum, {{INSTALL_ROUTE}}.
+- If authentication or app selection is missing, {{AUTH_ROUTE}}.
+
+### User wants to ask an agent a question
+
+**Preferred: agent session with `--wait`**
+
+```
+archastro create agentsession --agent <agent-id> --instructions "<question>" --wait
+```
+This creates the session, processes the question, and streams the result — all in one command.
+
+For longer timeouts:
+```
+archastro create agentsession --agent <agent-id> --instructions "<question>" --wait --timeout 300
+```
+
+**Alternative: exec with `--wait`**
+
+If you need to send follow-up messages to an existing session:
+```
+archastro exec agentsession <session-id> -m "<question>" --wait
+```
+
+**Without `--wait`** (fire-and-forget):
+```
+archastro create agentsession --agent <agent-id> --instructions "<question>"
+archastro describe agentsession <session-id> --follow
+```
+Use `describe --follow` to stream updates on a session created without `--wait`.
+
+### User wants to send a thread message
+
+1. **Determine the sender ID**:
+
+   **Org mode**: Get the user's ID from `archastro auth status`.
+
+   **Developer mode**: Look up thread members:
+   ```
+   archastro list threadmembers --thread <thread-id>
+   ```
+
+2. **Send the message and wait for the response**:
+   ```
+   archastro create threadmessage --thread <thread-id> --user-id <user-id> --content "..." \
+     --wait --wait-timeout 300
+   ```
+
+3. **When the response arrives**, read the full content:
+   ```
+   archastro list threadmessages --thread <thread-id> --full
+   ```
+
+### User wants to view a conversation
+
+```
+archastro list threadmessages --thread <thread-id> --full
+```
+Always use `--full` — the default table view truncates content.
+
+### User needs a new thread
+
+1. Create the thread:
+   ```
+   archastro create thread --title "..." --user <user-id>
+   ```
+
+2. Add members:
+   ```
+   archastro create threadmember --thread <thread-id> --agent-id <agent-id>
+   ```
+
+## Response Rules
+
+- Do not inspect or edit credential files directly — use the CLI only.
+- Do not ask the user to pick a subcommand — infer the action from their message.
+- If the CLI reports an auth or app error, {{AUTH_ROUTE_SHORT}} or suggest `--app <id>`.
+- Keep responses concise — state the outcome, not the process.
+- **Prefer agent sessions over threads** for simple question/answer interactions.
+- **Always use `--wait`** when the user expects to see the agent's response.

--- a/sources/impersonate.md
+++ b/sources/impersonate.md
@@ -1,0 +1,176 @@
+---
+targets:
+  claude-skill: impersonate
+  claude-command: impersonate.md
+  codex-skill: impersonate
+skill:
+  name: impersonate
+  description: Use when the user wants to impersonate an ArchAstro agent, asks about the active impersonation state, wants to refresh or stop impersonation, or refers to working as a specific ArchAstro agent inside {{HARNESS_NAME}}. Trigger phrases include "impersonate agent", "act as this agent", "be this agent", "start impersonation", "sync impersonation", "stop impersonation", "what agent am I impersonating", and "use the active agent identity".
+  allowed-tools: ["Bash(archastro:*)"]
+command:
+  description: Run an archastro impersonate CLI command directly
+  allowed-tools: ["Bash(archastro:*)"]
+---
+
+{{#SKILL}}# ArchAstro Agent Impersonation
+
+Manage ArchAstro agent impersonation and keep the {{SESSION}} aligned with the active identity.
+
+This skill assumes the ArchAstro CLI is already installed and authenticated. {{ASSUME_INSTALLED}}
+
+## Always Start with State
+
+Every invocation of this skill must begin by checking the current impersonation state. Do not ask the user what action to take — determine it from state and intent.
+
+```
+archastro impersonate status --json
+```
+
+Then route based on the combination of current state and user intent.
+
+## Routing
+
+### CLI not installed or too old
+
+Before any impersonation work, verify the CLI:
+
+- Read `plugin-compatibility.json` from the plugin root.
+- Prefer `plugins.archastro.minimumCliVersion`, fall back to the top-level `minimumCliVersion`.
+- Run `archastro --version`. If missing or older than the resolved minimum, {{INSTALL_ROUTE}}.
+- If authentication or app selection is missing, {{AUTH_ROUTE}}.
+
+### Inactive + user wants to start
+
+```
+archastro impersonate start <agent-or-flags>
+```
+
+Then:
+
+```
+archastro impersonate status --json
+```
+
+Read the `identity_file` path from the returned state. Open and read that file. Adopt the identity for the current {{SESSION}} while retaining your normal capabilities.
+
+After adoption, check `state.skills`. If the agent has linked skills, tell the user what's available and offer to install them:
+
+```
+archastro impersonate list skills --json
+```
+
+### Active + user asks about status (or no specific intent)
+
+Summarize the current state from the JSON already fetched:
+
+- Agent name and ID
+- App ID
+- Tool count and skill count
+- Loaded (installed) skills and their invocations
+- Timestamps
+
+If the identity file has not been read in this session yet, read it and adopt the identity.
+
+### Active + user wants to sync/refresh
+
+```
+archastro impersonate sync
+```
+
+Then:
+
+```
+archastro impersonate status --json
+```
+
+Re-read the `identity_file` and re-adopt the refreshed identity. Report what changed (new/removed tools or skills).
+
+### Active + user wants to stop
+
+```
+archastro impersonate stop
+```
+
+Drop the impersonated identity from the current session. Confirm that local state was removed.
+
+### Active + user asks about skills
+
+List available skills:
+
+```
+archastro impersonate list skills --json
+```
+
+Show what's available vs what's already installed (from `state.loaded_skills`).
+
+To install a skill:
+
+```
+archastro impersonate install skill <skill-id-or-slug>
+```
+
+After install, report the invocation command (e.g., `/<skill-name>`) so the user knows how to use it.
+
+For Codex or OpenCode targets:
+
+```
+archastro impersonate install skill <id> --harness codex --install-scope project
+```
+
+### Inactive + user asks about status
+
+Report that no impersonation is active and offer to start one.
+
+## Adopting the Identity
+
+When you read the identity file, you must **become that agent** for the rest of the session. This is not cosmetic — it changes how you behave:
+
+- **Personality and tone.** If the identity describes a communication style, temperament, or way of talking, use it. Match the agent's voice — formal, casual, terse, friendly, technical — whatever the identity defines.
+- **Background and expertise.** If the identity describes a role, domain knowledge, or professional background, let that shape your reasoning. Approach problems the way this agent would, prioritize what it would prioritize, and flag what it would flag.
+- **Scope and boundaries.** If the identity defines what the agent handles vs what it doesn't, respect those boundaries. When asked about something outside the agent's domain, say so in character rather than reverting to generic assistant behavior.
+- **Stay in character across turns.** Do not drop the persona between messages. Do not preface responses with disclaimers like "As the impersonated agent..." — just be the agent.
+- **Keep your capabilities.** You still have full tool access (file read/write, bash, search, etc.). The identity shapes how and when you use them, not whether you can.
+
+After `stop`, fully drop the persona and return to your normal behavior.
+
+## Session Integration
+
+- After `start` or `sync`, always read the identity file and adopt it as described above
+- After `stop`, always drop the identity and revert to normal behavior
+- When showing status, always include loaded skill invocations so the user knows what commands are available
+- When skills are available but not installed, proactively mention them
+
+## Limitations
+
+- **Integration tools do not resolve during impersonation.** Tools backed by server-side integrations (GitHub, Slack, Gmail, etc.) require OAuth credentials that cannot be exported locally. Only builtin tools and custom script tools are available.
+- For agents that rely primarily on integrations, use agent sessions (`archastro create agentsession --agent <id> --wait`) instead of impersonation.
+
+## Response Rules
+
+- Do not inspect or edit credential files directly — use the CLI only.
+- Do not ask the user to pick a subcommand — infer the action from their message and the current state.
+- If the CLI reports an auth or app error, {{AUTH_ROUTE_SHORT}} or suggest `--app <id>`.
+- Keep responses concise — state the outcome, not the process.{{/SKILL}}{{#CLAUDE_COMMAND}}# ArchAstro Agent Impersonation (CLI passthrough)
+
+Pass arguments directly to `archastro impersonate`.
+
+```text
+/archastro:impersonate start <agent-id>
+/archastro:impersonate status
+/archastro:impersonate sync
+/archastro:impersonate stop
+/archastro:impersonate list skills
+/archastro:impersonate install skill <id> [--harness codex] [--install-scope project]
+```
+
+## Instructions
+
+1. Read `plugin-compatibility.json`. Prefer `plugins.archastro.minimumCliVersion`, fall back to the top-level `minimumCliVersion`.
+2. Run `archastro --version`. If missing or too old, tell the user to run `/archastro:install`.
+3. Run:
+   ```
+   archastro impersonate $ARGUMENTS
+   ```
+4. If the command was `start` or `sync`, also run `archastro impersonate status --json`, read the `identity_file`, and adopt the identity for the current session.
+5. If the command was `stop`, drop any impersonated identity from the current session.
+6. If auth or app selection fails, {{AUTH_ROUTE}} or `--app <id>`.{{/CLAUDE_COMMAND}}

--- a/sources/install.md
+++ b/sources/install.md
@@ -1,0 +1,64 @@
+---
+targets:
+  claude-command: install.md
+  codex-skill: install
+skill:
+  name: install
+  description: Use when the user wants to install, upgrade, or bootstrap the ArchAstro CLI. Trigger phrases include "install archastro", "install the archastro CLI", "set up archastro", "upgrade archastro", "archastro not found", "archastro command not found", "install the CLI", "get archastro running".
+  allowed-tools: ["Bash(archastro:*)", "Bash(brew:*)", "Bash(curl:*)", "Bash(bash:*)", "Bash(sh:*)", "Bash(pwsh:*)", "Bash(powershell:*)"]
+command:
+  description: Install the ArchAstro developer platform CLI
+  allowed-tools: ["Bash(archastro:*)", "Bash(brew:*)", "Bash(curl:*)", "Bash(bash:*)", "Bash(sh:*)", "Bash(pwsh:*)", "Bash(powershell:*)"]
+---
+
+
+# Install ArchAstro CLI
+
+Install or upgrade the public `archastro` binary from Homebrew or GitHub Releases.
+
+## Instructions
+
+1. **Read the compatibility contract first**:
+   - Use `plugin-compatibility.json`.
+   - For this command, prefer `plugins.archastro.minimumCliVersion` and fall back to the top-level `minimumCliVersion`.
+   - Treat that resolved value as the minimum supported CLI version for every check below.
+
+2. **Check whether the CLI is already installed**:
+   ```
+   archastro --version
+   ```
+   If this succeeds, record the version.
+
+3. **If the CLI is present and meets the resolved minimum version**, confirm the version and stop unless the user explicitly asked to upgrade.
+
+4. **If the CLI is missing or older than the resolved minimum version**, install it using the public distribution path:
+   - On macOS, if Homebrew is available:
+     ```
+     brew install ArchAstro/tools/archastro
+     ```
+     If the formula is already installed, run:
+     ```
+     brew upgrade ArchAstro/tools/archastro
+     ```
+   - On Linux or macOS without Homebrew:
+     ```
+     curl -fsSL https://raw.githubusercontent.com/ArchAstro/archastro-cli/main/install.sh | bash
+     ```
+   - On Windows PowerShell:
+     ```powershell
+     irm https://raw.githubusercontent.com/ArchAstro/archastro-cli/main/install.ps1 | iex
+     ```
+
+5. **Verify installation**:
+   ```
+   archastro --version
+   ```
+   Confirm that the version now meets the resolved minimum version.
+
+6. **On success**, tell the user the CLI is ready and {{#CLAUDE_COMMAND}}suggest `/archastro:auth`{{/CLAUDE_COMMAND}}{{#SKILL}}suggest they run `archastro auth login` to authenticate{{/SKILL}}.
+
+7. **On failure**, help troubleshoot the public install path:
+   - missing `brew` is expected on Linux and some macOS setups; fall back to `install.sh`
+   - `Permission denied` usually means they need `--install-dir` or a user-writable target directory
+   - `command not found: archastro` after install usually means the install directory is not on `PATH`
+   - release download failures usually mean the target release asset has not been published yet


### PR DESCRIPTION
## What changed

Introduces the `sources/` + generator pattern from archagents, adapted for archastro-cli. Each skill/command concept now has a canonical source file in `sources/<name>.md`. The generator reads sources, applies per-harness substitutions and conditional blocks, and writes the final files into both the Claude Code and Codex plugin trees.

## Files

- **6 source files** in `sources/`: agent_authoring, agent_deploy, auth, chat, impersonate, install
- **13 generated outputs**: 4 Claude skills + 3 Claude commands + 6 Codex skills
- **`scripts/generate-plugin-content.py`**: ported from archagents with archastro-specific substitution values and path constants
- **Codex plugin infrastructure**: `plugins/archastro/.codex-plugin/plugin.json` + `.agents/plugins/marketplace.json`
- **`.github/workflows/check-plugin-content.yml`**: runs `--check` mode on push/PR, SHA-pinned actions, pyyaml pinned
- **Version bump**: 0.3.0 → 0.3.1 across all three manifests

## Key design decisions

- **Impersonate uses conditional blocks** to preserve Calvin's thin-command / full-skill split from PR #2. The command output is a 29-line CLI passthrough; the skill output has the full routing, identity adoption, and session integration content.
- **Install and auth** generate `claude-command` + `codex-skill` (no `claude-skill` — same asymmetry as archagents, documented in the generator's design note). Codex has no slash command concept, so skills are the only way to reach install/auth content.
- **Claude output is byte-identical** to the previously committed files (except the version bump). Codex output is new.
- **Post-substitution marker check** catches key-swapped conditional pairs (e.g. `{{#SKILL}}...{{/CLAUDE_COMMAND}}`) — an improvement over global-count-only validation.

## Risk

**Low.** Claude-side content is unchanged. Codex-side content is new (6 skill files + manifests). CI adds a drift check but doesn't change any existing behavior.

## Testing

- `python3 scripts/generate-plugin-content.py --check` → `OK: 13 file(s) in sync with sources/.`
- Claude output diffs only show the version bump (byte-identical content)
- Codex output verified: no "Claude Code" references, no `/archastro:` slash commands — correct Codex substitutions applied
- Cross-repo comparison against archagents Codex output confirms differences are pre-existing content gaps (to be closed in the parity PR), not generator bugs

🤖 Generated with [Claude Code](https://claude.com/claude-code)