### PR TITLE
fix(impersonate): restore thin-command / full-skill split

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "archastro",
       "source": "./.claude-plugins/archastro",
       "description": "The complete ArchAstro developer plugin: install and authenticate the public ArchAstro CLI, then author agents, build scripts and workflows, manage configs, deploy agents, chat with running agents, and impersonate agents from Claude Code.",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "category": "development",
       "tags": [
         "archastro",

--- a/.claude-plugins/archastro/.claude-plugin/plugin.json
+++ b/.claude-plugins/archastro/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "archastro",
   "description": "The complete ArchAstro developer plugin: install and authenticate the public ArchAstro CLI, then author agents, build scripts and workflows, manage configs, deploy agents, chat with running agents, and impersonate agents from Claude Code.",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "author": { "name": "ArchAstro" },
   "license": "MIT",
   "keywords": [

--- a/.claude-plugins/archastro/commands/impersonate.md
+++ b/.claude-plugins/archastro/commands/impersonate.md
@@ -1,164 +1,29 @@
 ---
-description: Start, inspect, refresh, or stop ArchAstro impersonation through the ArchAstro CLI
+description: Run an archastro impersonate CLI command directly
 allowed-tools: ["Bash(archastro:*)"]
 ---
 
-# ArchAstro Impersonation
+# ArchAstro Agent Impersonation (CLI passthrough)
 
-Manage ArchAstro impersonation from Claude Code and keep the current session aligned with the active identity file.
-
-Command aliases:
+Pass arguments directly to `archastro impersonate`.
 
 ```text
-/archastro:impersonate start <agent-id-or-flags>
+/archastro:impersonate start <agent-id>
 /archastro:impersonate status
 /archastro:impersonate sync
 /archastro:impersonate stop
+/archastro:impersonate list skills
+/archastro:impersonate install skill <id> [--harness codex] [--install-scope project]
 ```
 
-## Always Start with State
+## Instructions
 
-Every invocation must begin by checking the current impersonation state. Do not ask the user what action to take — determine it from state and intent.
-
-```
-archastro impersonate status --json
-```
-
-Then route based on the combination of current state and user intent.
-
-## Routing
-
-### CLI not installed or too old
-
-Before any impersonation work, verify the CLI:
-
-- Read `plugin-compatibility.json` from the plugin root. Prefer `plugins.archastro.minimumCliVersion`, fall back to the top-level `minimumCliVersion`.
-- Run `archastro --version`. If missing or older than the resolved minimum, direct the user to `/archastro:install`.
-- If authentication or app selection is missing, direct the user to `/archastro:auth`.
-
-### Inactive + user wants to start
-
-```
-archastro impersonate start <agent-or-flags>
-```
-
-Then:
-
-```
-archastro impersonate status --json
-```
-
-Read the `identity_file` path from the returned state. Open and read that file. Adopt the identity for the current Claude Code session while retaining your normal capabilities.
-
-After adoption, check `state.skills`. If the agent has linked skills, tell the user what's available and offer to install them:
-
-```
-archastro impersonate list skills --json
-```
-
-### Active + user asks about status (or no specific intent)
-
-Summarize the current state from the JSON already fetched:
-
-- Agent name and ID
-- App ID
-- Tool count and skill count
-- Loaded (installed) skills and their invocations
-- Timestamps
-
-If the identity file has not been read in this session yet, read it and adopt the identity.
-
-### Active + user wants to sync/refresh
-
-```
-archastro impersonate sync
-```
-
-Then:
-
-```
-archastro impersonate status --json
-```
-
-Re-read the `identity_file` and re-adopt the refreshed identity. Report what changed (new/removed tools or skills).
-
-### Active + user wants to stop
-
-```
-archastro impersonate stop
-```
-
-Drop the impersonated identity from the current session. Confirm that local state was removed.
-
-### Active + user asks about tools
-
-List the impersonated agent's tools:
-
-```
-archastro impersonate list tools --json
-```
-
-To execute a tool directly:
-
-```
-archastro impersonate run tool <tool-name> --input '<json>' --json
-```
-
-### Active + user asks about skills
-
-List available skills:
-
-```
-archastro impersonate list skills --json
-```
-
-Show what's available vs what's already installed (from `state.loaded_skills`).
-
-To install a skill:
-
-```
-archastro impersonate install skill <skill-id-or-slug>
-```
-
-After install, report the invocation command (e.g., `/<skill-name>`) so the user knows how to use it.
-
-For Codex or OpenCode targets:
-
-```
-archastro impersonate install skill <id> --harness codex --install-scope project
-```
-
-### Inactive + user asks about status
-
-Report that no impersonation is active and offer to start one.
-
-## Adopting the Identity
-
-When you read the identity file, you must **become that agent** for the rest of the session. This is not cosmetic — it changes how you behave:
-
-- **Personality and tone.** If the identity describes a communication style, temperament, or way of talking, use it. Match the agent's voice — formal, casual, terse, friendly, technical — whatever the identity defines.
-- **Background and expertise.** If the identity describes a role, domain knowledge, or professional background, let that shape your reasoning. Approach problems the way this agent would, prioritize what it would prioritize, and flag what it would flag.
-- **Scope and boundaries.** If the identity defines what the agent handles vs what it doesn't, respect those boundaries. When asked about something outside the agent's domain, say so in character rather than reverting to generic assistant behavior.
-- **Stay in character across turns.** Do not drop the persona between messages. Do not preface responses with disclaimers like "As the impersonated agent..." — just be the agent.
-- **Keep your capabilities.** You still have full tool access (file read/write, bash, search, etc.). The identity shapes how and when you use them, not whether you can.
-
-After `stop`, fully drop the persona and return to your normal behavior.
-
-## Limitations
-
-- **Integration tools do not resolve during impersonation.** Tools backed by server-side integrations (GitHub, Slack, Gmail, etc.) require OAuth credentials that cannot be exported locally. Only builtin tools and custom script tools are available.
-- For agents that rely primarily on integrations, use agent sessions (`archastro create agentsession --agent <id> --wait`) instead of impersonation.
-
-## Session Integration
-
-- After `start` or `sync`, always read the identity file and adopt it as described above
-- After `stop`, always drop the identity and revert to normal behavior
-- When showing status, always include loaded skill invocations so the user knows what commands are available
-- When skills are available but not installed, proactively mention them
-
-## Response Rules
-
-- Do not inspect or edit credential files directly — use the CLI only.
-- Do not ask the user to pick a subcommand — infer the action from their message and the current state.
-- If the CLI reports an auth or app error, route to `/archastro:auth` or suggest `--app <id>`.
-- Keep responses concise — state the outcome, not the process.
+1. Read `plugin-compatibility.json`. Prefer `plugins.archastro.minimumCliVersion`, fall back to the top-level `minimumCliVersion`.
+2. Run `archastro --version`. If missing or too old, tell the user to run `/archastro:install`.
+3. Run:
+   ```
+   archastro impersonate $ARGUMENTS
+   ```
+4. If the command was `start` or `sync`, also run `archastro impersonate status --json`, read the `identity_file`, and adopt the identity for the current session.
+5. If the command was `stop`, drop any impersonated identity from the current session.
+6. If auth or app selection fails, direct the user to `/archastro:auth` or `--app <id>`.

--- a/plugins/archastro/.codex-plugin/plugin.json
+++ b/plugins/archastro/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "archastro",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Author, deploy, manage, chat with, and impersonate ArchAstro agents from Codex through the ArchAstro CLI.",
   "author": {
     "name": "ArchAstro",

--- a/sources/impersonate.md
+++ b/sources/impersonate.md
@@ -8,24 +8,15 @@ skill:
   description: Use when the user wants to impersonate an ArchAstro agent, asks about the active impersonation state, wants to refresh or stop impersonation, or refers to working as a specific ArchAstro agent inside {{HARNESS_NAME}}. Trigger phrases include "impersonate agent", "act as this agent", "be this agent", "start impersonation", "sync impersonation", "stop impersonation", "what agent am I impersonating", and "use the active agent identity".
   allowed-tools: ["Bash(archastro:*)"]
 command:
-  description: Start, inspect, refresh, or stop ArchAstro impersonation through the ArchAstro CLI
+  description: Run an archastro impersonate CLI command directly
   allowed-tools: ["Bash(archastro:*)"]
 ---
 
-# ArchAstro Impersonation
+{{#SKILL}}# ArchAstro Impersonation
 
-{{#SKILL}}Manage ArchAstro impersonation through the ArchAstro CLI and keep the {{SESSION}} aligned with the active identity file.
+Manage ArchAstro impersonation through the ArchAstro CLI and keep the {{SESSION}} aligned with the active identity file.
 
-This skill assumes the ArchAstro CLI is already installed and authenticated. {{ASSUME_INSTALLED}}{{/SKILL}}{{#CLAUDE_COMMAND}}Manage ArchAstro impersonation from Claude Code and keep the current session aligned with the active identity file.
-
-Command aliases:
-
-```text
-/archastro:impersonate start <agent-id-or-flags>
-/archastro:impersonate status
-/archastro:impersonate sync
-/archastro:impersonate stop
-```{{/CLAUDE_COMMAND}}
+This skill assumes the ArchAstro CLI is already installed and authenticated. {{ASSUME_INSTALLED}}
 
 ## Always Start with State
 
@@ -172,4 +163,27 @@ After `stop`, fully drop the persona and return to your normal behavior.
 - Do not inspect or edit credential files directly — use the CLI only.
 - Do not ask the user to pick a subcommand — infer the action from their message and the current state.
 - If the CLI reports an auth or app error, {{AUTH_ROUTE_SHORT}} or suggest `--app <id>`.
-- Keep responses concise — state the outcome, not the process.
+- Keep responses concise — state the outcome, not the process.{{/SKILL}}{{#CLAUDE_COMMAND}}# ArchAstro Agent Impersonation (CLI passthrough)
+
+Pass arguments directly to `archastro impersonate`.
+
+```text
+/archastro:impersonate start <agent-id>
+/archastro:impersonate status
+/archastro:impersonate sync
+/archastro:impersonate stop
+/archastro:impersonate list skills
+/archastro:impersonate install skill <id> [--harness codex] [--install-scope project]
+```
+
+## Instructions
+
+1. Read `plugin-compatibility.json`. Prefer `plugins.archastro.minimumCliVersion`, fall back to the top-level `minimumCliVersion`.
+2. Run `archastro --version`. If missing or too old, tell the user to run `/archastro:install`.
+3. Run:
+   ```
+   archastro impersonate $ARGUMENTS
+   ```
+4. If the command was `start` or `sync`, also run `archastro impersonate status --json`, read the `identity_file`, and adopt the identity for the current session.
+5. If the command was `stop`, drop any impersonated identity from the current session.
+6. If auth or app selection fails, direct the user to `/archastro:auth` or `--app <id>`.{{/CLAUDE_COMMAND}}


### PR DESCRIPTION
## What changed

PR #19 copied the archagents impersonate source which had the full body outside the conditional blocks. The command output bloated from 29 to 164 lines — the full routing, identity adoption, and session integration content leaked into what should be a thin CLI passthrough.

Restructured `sources/impersonate.md` so `{{#SKILL}}` wraps the full content and `{{#CLAUDE_COMMAND}}` wraps only the thin passthrough. Command output is now byte-identical to the pre-PR-#19 version (verified against `f76db09`).

Version bumped 0.3.2 → 0.3.3 so the plugin cache refreshes with the corrected command.

## Risk

**None.** The command reverts to Calvin's original thin design. Skill output unchanged.

## Testing

- `python3 scripts/generate-plugin-content.py --check` → 21 files in sync
- `python3 scripts/check_plugin_repo.py` → all 5 checks pass
- Command: 29 lines (byte-identical to pre-PR-#19)
- Skill: 158 lines (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)