### PR TITLE
Fix Unix installer portability in sandboxed Linux

### DIFF
--- a/.github/workflows/installer-smoke-test.yml
+++ b/.github/workflows/installer-smoke-test.yml
@@ -8,6 +8,18 @@ on:
   workflow_dispatch:
 
 jobs:
+  linux-installer-without-dev-fd:
+    name: Linux Installer Without dev fd
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Install across the Vercel Sandbox boundary
+        run: |
+          chmod +x ./install.sh ./scripts/create-unix-fixtures.sh ./scripts/test-installer-without-dev-fd.sh
+          ./scripts/test-installer-without-dev-fd.sh
+
   unix-installer:
     name: Unix Installer (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/install.sh
+++ b/install.sh
@@ -127,8 +127,11 @@ case "$ARCH" in
 esac
 
 if [[ "$PLATFORM" == "linux" && "$ARCH_LABEL" == "x64" ]]; then
-  if command -v ldd >/dev/null 2>&1 && ldd --version 2>&1 | grep -qi "musl"; then
-    ARCH_LABEL="x64-musl"
+  if command -v ldd >/dev/null 2>&1; then
+    LDD_VERSION="$(ldd --version 2>&1 || true)"
+    if printf '%s\n' "$LDD_VERSION" | grep -i "musl" >/dev/null; then
+      ARCH_LABEL="x64-musl"
+    fi
   fi
 fi
 
@@ -236,16 +239,10 @@ fi
 mkdir -p "$EXTRACT_DIR"
 tar -xzf "$ASSET_PATH" -C "$EXTRACT_DIR"
 
-FOUND_BINARY=""
-while IFS= read -r candidate; do
-  if [[ "$(basename "$candidate")" == "$BINARY_NAME" ]]; then
-    FOUND_BINARY="$candidate"
-    break
-  fi
-done < <(find "$EXTRACT_DIR" -type f)
+FOUND_BINARY="$(find "$EXTRACT_DIR" -type f -name "$BINARY_NAME" -print | sed -n '1p')"
 
 if [[ -z "$FOUND_BINARY" ]]; then
-  FOUND_BINARY="$(find "$EXTRACT_DIR" -type f | head -n 1 || true)"
+  FOUND_BINARY="$(find "$EXTRACT_DIR" -type f -print | sed -n '1p')"
 fi
 
 if [[ -z "$FOUND_BINARY" ]]; then

--- a/scripts/test-installer-without-dev-fd.sh
+++ b/scripts/test-installer-without-dev-fd.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+#
+# Canonical end-to-end proof for Vercel Sandbox-compatible installation.
+#
+# A real Linux container serves a fixture release over HTTP, removes /dev/fd
+# to reproduce the sandbox boundary, and runs install.sh as a user would.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+FIXTURE_DIR="$(mktemp -d)"
+trap 'rm -rf "$FIXTURE_DIR"' EXIT
+
+"$ROOT_DIR/scripts/create-unix-fixtures.sh" \
+  --output-dir "$FIXTURE_DIR" \
+  --version 0.3.1 \
+  --platform linux \
+  --arch-label x64-musl
+
+docker run --rm \
+  --platform linux/amd64 \
+  --volume "$ROOT_DIR:/workspace:ro" \
+  --volume "$FIXTURE_DIR:/release:ro" \
+  alpine:3.22@sha256:14358309a308569c32bdc37e2e0e9694be33a9d99e68afb0f5ff33cc1f695dce \
+  /bin/sh -eu -c '
+    apk add --no-cache bash coreutils curl python3 >/dev/null
+
+    # Reproduce Vercel Sandbox before crossing the installer boundary.
+    rm -f /dev/fd
+    test ! -e /dev/fd
+
+    # Serve the release exactly as the installer expects to fetch it.
+    cd /release
+    python3 -m http.server 8123 --bind 127.0.0.1 >/tmp/fixtures.log 2>&1 &
+    server_pid=$!
+    trap "kill $server_pid" EXIT
+    for attempt in $(seq 1 20); do
+      if curl -fsS http://127.0.0.1:8123/SHA256SUMS >/dev/null; then
+        break
+      fi
+      if [ "$attempt" -eq 20 ]; then
+        cat /tmp/fixtures.log
+        exit 1
+      fi
+      sleep 1
+    done
+
+    # Run the real installer and assert its externally observable result.
+    mkdir -p /tmp/home
+    HOME=/tmp/home \
+      SHELL=/bin/bash \
+      ARCHASTRO_RELEASE_BASE_URL=http://127.0.0.1:8123 \
+      ARCHASTRO_VERSION=0.3.1 \
+      ARCHASTRO_INSTALL_DIR=/tmp/home/.local/bin \
+      ARCHASTRO_INSTALL_SKIP_PATH_UPDATE=true \
+      ARCHASTRO_INSTALL_SKIP_COMPLETIONS=true \
+      /workspace/install.sh
+
+    test "$(/tmp/home/.local/bin/archastro --version)" = "0.3.1"
+  '


### PR DESCRIPTION
## What changed

- Removed Bash process substitution from binary discovery so the Unix installer no longer requires `/dev/fd`.
- Fixed musl detection by capturing `ldd` output before matching it, avoiding the `pipefail` and `grep -q` SIGPIPE interaction that selected the glibc asset on Alpine.
- Added a digest-pinned Linux end-to-end test that serves a release fixture over HTTP, removes `/dev/fd`, runs the real installer, and executes the installed CLI.

## Scope

CLI tooling only. This changes the Unix installer and its CI coverage; no backend, frontend, API, or release artifact code changes.

## Runtime flow

```mermaid
sequenceDiagram
    participant Caller as CLI installer caller
    participant Installer as Unix installer
    participant Runtime as Linux runtime
    participant Server as Release server
    Caller->>Installer: Start installation
    Installer->>Runtime: Inspect ldd output
    alt musl runtime
        Runtime-->>Installer: Report musl
        Installer->>Server: Download x64-musl archive and checksum
    else glibc runtime
        Runtime-->>Installer: Report glibc
        Installer->>Server: Download x64 archive and checksum
    end
    Installer->>Runtime: Extract archive
    Installer->>Runtime: Find binary without dev fd
    Installer->>Runtime: Install and execute binary
    Runtime-->>Caller: Return version output
```

## Installer structure

```mermaid
classDiagram
    class Installer {
        +String platform
        +String archLabel
        +String binaryName
        +detectRuntime()
        +selectBinary()
        +install()
    }
    class LinuxRuntime {
        +String libc
        +Boolean hasDevFd
    }
    class ReleaseArchive {
        +String assetName
        +String checksum
    }
    class InstalledBinary {
        +String name
        +version()
    }
    Installer --> LinuxRuntime : inspects
    Installer --> ReleaseArchive : downloads
    ReleaseArchive *-- InstalledBinary : contains
    Installer --> InstalledBinary : installs
```

## Risk assessment

Medium-low. This touches the direct installation path, so a regression could block new CLI installs. The implementation replaces one non-portable discovery loop with standard `find` and `sed`, preserves the unnamed-binary fallback, and is covered by the existing macOS/Linux matrix plus the new isolated Linux proof.

## User impact

Users can install ArchAstro inside Vercel Sandbox and other Linux environments without `/dev/fd`. Alpine and other musl users now receive the correct `linux-x64-musl` artifact instead of the glibc artifact.

## Testing

### Canonical end-to-end proof

[`scripts/test-installer-without-dev-fd.sh`](https://github.com/ArchAstro/archastro/blob/cd2f125/scripts/test-installer-without-dev-fd.sh) is the canonical proof.

The script reads top-to-bottom as the user/system story:

- generates a real `archastro-linux-x64-musl.tar.gz` fixture and checksum;
- starts a separate Alpine Linux container and a real HTTP release server;
- removes `/dev/fd` and asserts that boundary before invoking `install.sh`;
- crosses HTTP, checksum, archive extraction, filesystem installation, and executable process boundaries;
- asserts the installed binary reports version `0.3.1`.

It failed before the fix with `/dev/fd/63: No such file or directory` after checksum verification, then passed after the fix while explicitly downloading the musl archive.

### Focused verification

- `./scripts/test-installer-without-dev-fd.sh` — passed
- `bash -n install.sh scripts/create-unix-fixtures.sh scripts/test-installer-without-dev-fd.sh` — passed
- `shellcheck -e SC2016 install.sh scripts/create-unix-fixtures.sh scripts/test-installer-without-dev-fd.sh` — passed
- `actionlint -shellcheck= .github/workflows/installer-smoke-test.yml` — passed
- `git diff --check` — passed
- Independent adversarial review reran the E2E and found no remaining blockers.

The exact `curl ... | bash` wrapper is not part of the proof; the test executes the same installer file directly after crossing the release HTTP boundary. Existing Ubuntu, macOS, and Windows installer smoke jobs remain the broader CI gate.

## Follow-ups and known issues

No deferred installer correctness work is known. The test pins the Alpine image digest; its package installation still depends on Alpine's package network, as the existing installer tests depend on their fixture tooling.
