### PR TITLE
Use canonical ArchAstro repository URLs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "archastro",
       "source": "./.claude-plugins/archastro",
       "description": "The complete ArchAstro developer plugin: install and authenticate the public ArchAstro CLI, then author agents, build scripts and workflows, manage configs, deploy agents, chat with running agents, and impersonate agents from Claude Code.",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "category": "development",
       "tags": [
         "archastro",

--- a/.claude-plugins/archastro/.claude-plugin/plugin.json
+++ b/.claude-plugins/archastro/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "archastro",
   "description": "The complete ArchAstro developer plugin: install and authenticate the public ArchAstro CLI, then author agents, build scripts and workflows, manage configs, deploy agents, chat with running agents, and impersonate agents from Claude Code.",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "author": { "name": "ArchAstro" },
   "license": "MIT",
   "keywords": [

--- a/.claude-plugins/archastro/commands/install.md
+++ b/.claude-plugins/archastro/commands/install.md
@@ -33,11 +33,11 @@ Install or upgrade the public `archastro` binary from Homebrew or GitHub Release
      ```
    - On Linux or macOS without Homebrew:
      ```
-     curl -fsSL https://raw.githubusercontent.com/ArchAstro/archastro-cli/main/install.sh | bash
+     curl -fsSL https://raw.githubusercontent.com/ArchAstro/archastro/main/install.sh | bash
      ```
    - On Windows PowerShell:
      ```powershell
-     irm https://raw.githubusercontent.com/ArchAstro/archastro-cli/main/install.ps1 | iex
+     irm https://raw.githubusercontent.com/ArchAstro/archastro/main/install.ps1 | iex
      ```
 
 5. **Verify installation**:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ brew install ArchAstro/tools/archastro
 Fallback to the installer script:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/ArchAstro/archastro-cli/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/ArchAstro/archastro/main/install.sh | bash
 ```
 
 ### Linux
@@ -25,7 +25,7 @@ curl -fsSL https://raw.githubusercontent.com/ArchAstro/archastro-cli/main/instal
 Use the installer script:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/ArchAstro/archastro-cli/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/ArchAstro/archastro/main/install.sh | bash
 ```
 
 ### Windows
@@ -33,7 +33,7 @@ curl -fsSL https://raw.githubusercontent.com/ArchAstro/archastro-cli/main/instal
 Use the PowerShell installer:
 
 ```powershell
-irm https://raw.githubusercontent.com/ArchAstro/archastro-cli/main/install.ps1 | iex
+irm https://raw.githubusercontent.com/ArchAstro/archastro/main/install.ps1 | iex
 ```
 
 ## Claude Code Plugin
@@ -41,7 +41,7 @@ irm https://raw.githubusercontent.com/ArchAstro/archastro-cli/main/install.ps1 |
 Add the marketplace and install the `archastro` plugin:
 
 ```text
-/plugin marketplace add archastro/archastro-cli
+/plugin marketplace add archastro/archastro
 /plugin install archastro@archastro
 ```
 

--- a/install.ps1
+++ b/install.ps1
@@ -27,7 +27,7 @@ function Resolve-BoolEnv {
 }
 
 $Owner = "ArchAstro"
-$Repo = "archastro-cli"
+$Repo = "archastro"
 $BinaryName = "archastro.exe"
 
 if ([string]::IsNullOrWhiteSpace($Version)) {

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 OWNER="ArchAstro"
-REPO="archastro-cli"
+REPO="archastro"
 BINARY_NAME="archastro"
 DEFAULT_VERSION="latest"
 INSTALL_DIR="${ARCHASTRO_INSTALL_DIR:-}"

--- a/plugins/archastro/.codex-plugin/plugin.json
+++ b/plugins/archastro/.codex-plugin/plugin.json
@@ -1,14 +1,14 @@
 {
   "name": "archastro",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Author, deploy, manage, chat with, and impersonate ArchAstro agents from Codex through the ArchAstro CLI.",
   "author": {
     "name": "ArchAstro",
     "email": "dev@archastro.com",
     "url": "https://github.com/ArchAstro"
   },
-  "homepage": "https://github.com/ArchAstro/archastro-cli",
-  "repository": "https://github.com/ArchAstro/archastro-cli",
+  "homepage": "https://github.com/ArchAstro/archastro",
+  "repository": "https://github.com/ArchAstro/archastro",
   "license": "MIT",
   "keywords": [
     "archastro",
@@ -31,7 +31,7 @@
       "Write",
       "Shell"
     ],
-    "websiteURL": "https://github.com/ArchAstro/archastro-cli",
+    "websiteURL": "https://github.com/ArchAstro/archastro",
     "defaultPrompt": [
       "Author a config-driven ArchAstro agent.",
       "Set up local configs for this repo.",

--- a/plugins/archastro/skills/install/SKILL.md
+++ b/plugins/archastro/skills/install/SKILL.md
@@ -34,11 +34,11 @@ Install or upgrade the public `archastro` binary from Homebrew or GitHub Release
      ```
    - On Linux or macOS without Homebrew:
      ```
-     curl -fsSL https://raw.githubusercontent.com/ArchAstro/archastro-cli/main/install.sh | bash
+     curl -fsSL https://raw.githubusercontent.com/ArchAstro/archastro/main/install.sh | bash
      ```
    - On Windows PowerShell:
      ```powershell
-     irm https://raw.githubusercontent.com/ArchAstro/archastro-cli/main/install.ps1 | iex
+     irm https://raw.githubusercontent.com/ArchAstro/archastro/main/install.ps1 | iex
      ```
 
 5. **Verify installation**:

--- a/scripts/check_plugin_repo.py
+++ b/scripts/check_plugin_repo.py
@@ -33,6 +33,7 @@ ERROR CONTRACT
 CHECKS
     Implemented: check_manifest_consistency, check_compat_key_refs,
                  check_slash_command_refs, check_hardcoded_versions,
+                 check_legacy_repository_refs,
                  check_version_bump_on_content_change
 """
 from __future__ import annotations
@@ -68,6 +69,20 @@ CONTENT_ROOTS: list[Path] = [
     REPO_ROOT / ".claude-plugins" / "archastro" / "commands",
     REPO_ROOT / "plugins" / "archastro" / "skills",
 ]
+
+PUBLIC_REPOSITORY_REFERENCE_FILES: tuple[Path, ...] = (
+    REPO_ROOT / "README.md",
+    REPO_ROOT / "install.sh",
+    REPO_ROOT / "install.ps1",
+    REPO_ROOT / "sources" / "install.md",
+    REPO_ROOT / ".claude-plugins" / "archastro" / "commands" / "install.md",
+    REPO_ROOT / "plugins" / "archastro" / "skills" / "install" / "SKILL.md",
+    REPO_ROOT / "plugins" / "archastro" / ".codex-plugin" / "plugin.json",
+)
+
+LEGACY_REPOSITORY_SLUG = "ArchAstro/archastro-cli"
+LEGACY_REPOSITORY_NAME = "archastro-cli"
+CANONICAL_REPOSITORY_SLUG = "ArchAstro/archastro"
 
 
 def _rel(p: Path) -> str:
@@ -125,6 +140,27 @@ def _load_json_dict(path: Path) -> tuple[dict | None, str | None]:
     if not isinstance(data, dict):
         return None, f"{_rel(path)}: top-level JSON is not an object"
     return data, None
+
+
+def check_legacy_repository_refs(
+    files: Iterable[Path] = PUBLIC_REPOSITORY_REFERENCE_FILES,
+) -> list[str]:
+    """Reject public links that still use the repository's pre-rename slug."""
+    errors: list[str] = []
+    for path in files:
+        try:
+            lines = path.read_text(encoding="utf-8").splitlines()
+        except OSError as exc:
+            errors.append(f"{_rel(path)}: cannot read ({exc})")
+            continue
+        for lineno, line in enumerate(lines, start=1):
+            if LEGACY_REPOSITORY_NAME in line.lower():
+                errors.append(
+                    f"{_rel(path)}:{lineno}: references renamed repository "
+                    f"`{LEGACY_REPOSITORY_SLUG}`; use "
+                    f"`{CANONICAL_REPOSITORY_SLUG}`"
+                )
+    return errors
 
 
 def check_manifest_consistency(
@@ -586,6 +622,7 @@ def check_version_bump_on_content_change(
 # manifest's version against the PR base).
 CHECKS: list[tuple[str, Callable[[], list[str]]]] = [
     ("manifest consistency", check_manifest_consistency),
+    ("canonical repository refs", check_legacy_repository_refs),
     ("compat key refs", check_compat_key_refs),
     ("slash command refs", check_slash_command_refs),
     ("hardcoded versions", check_hardcoded_versions),

--- a/scripts/test_check_plugin_repo.py
+++ b/scripts/test_check_plugin_repo.py
@@ -231,6 +231,55 @@ class ManifestConsistencyTest(unittest.TestCase):
         self.assertTrue(any("codex-plugin.json" in e for e in errors))
 
 
+class LegacyRepositoryRefsTest(unittest.TestCase):
+    """Tests for check_legacy_repository_refs()."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.tmp = Path(self._tmp.name)
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def test_canonical_repository_urls_pass(self):
+        path = self.tmp / "README.md"
+        path.write_text("https://github.com/ArchAstro/archastro\n")
+        self.assertEqual(
+            check_plugin_repo.check_legacy_repository_refs(files=[path]),
+            [],
+        )
+
+    def test_default_file_set_covers_both_installers(self):
+        self.assertIn(
+            check_plugin_repo.REPO_ROOT / "install.sh",
+            check_plugin_repo.PUBLIC_REPOSITORY_REFERENCE_FILES,
+        )
+        self.assertIn(
+            check_plugin_repo.REPO_ROOT / "install.ps1",
+            check_plugin_repo.PUBLIC_REPOSITORY_REFERENCE_FILES,
+        )
+
+    def test_renamed_repository_url_fails_with_line_number(self):
+        path = self.tmp / "README.md"
+        path.write_text(
+            "# Install\n"
+            "https://raw.githubusercontent.com/ArchAstro/archastro-cli/main/install.sh\n"
+        )
+        errors = check_plugin_repo.check_legacy_repository_refs(files=[path])
+        self.assertEqual(len(errors), 1)
+        self.assertIn(f"{path}:2:", errors[0])
+        self.assertIn("ArchAstro/archastro-cli", errors[0])
+        self.assertIn("ArchAstro/archastro", errors[0])
+
+    def test_separate_repository_variable_fails(self):
+        path = self.tmp / "install.ps1"
+        path.write_text('$Owner = "ArchAstro"\n$Repo = "archastro-cli"\n')
+        errors = check_plugin_repo.check_legacy_repository_refs(files=[path])
+        self.assertEqual(len(errors), 1)
+        self.assertIn(f"{path}:2:", errors[0])
+        self.assertIn("archastro-cli", errors[0])
+
+
 class CompatKeyRefsTest(unittest.TestCase):
     """Tests for check_compat_key_refs()."""
 
@@ -1155,7 +1204,7 @@ class MainRunnerTest(unittest.TestCase):
     # Real CHECKS registry sanity ----------------------------------------
 
     def test_real_checks_registry_has_expected_entries(self):
-        # The real CHECKS list should contain all 5 checks in the expected
+        # The real CHECKS list should contain all 6 checks in the expected
         # order. This guards against accidental removal or reordering that
         # would break invariants documented in the comment above CHECKS.
         names = [name for name, _ in self._original_checks]
@@ -1163,6 +1212,7 @@ class MainRunnerTest(unittest.TestCase):
             names,
             [
                 "manifest consistency",
+                "canonical repository refs",
                 "compat key refs",
                 "slash command refs",
                 "hardcoded versions",

--- a/sources/install.md
+++ b/sources/install.md
@@ -41,11 +41,11 @@ Install or upgrade the public `archastro` binary from Homebrew or GitHub Release
      ```
    - On Linux or macOS without Homebrew:
      ```
-     curl -fsSL https://raw.githubusercontent.com/ArchAstro/archastro-cli/main/install.sh | bash
+     curl -fsSL https://raw.githubusercontent.com/ArchAstro/archastro/main/install.sh | bash
      ```
    - On Windows PowerShell:
      ```powershell
-     irm https://raw.githubusercontent.com/ArchAstro/archastro-cli/main/install.ps1 | iex
+     irm https://raw.githubusercontent.com/ArchAstro/archastro/main/install.ps1 | iex
      ```
 
 5. **Verify installation**:


### PR DESCRIPTION
## What changed

- use `ArchAstro/archastro` in macOS, Linux, and Windows install URLs
- update Claude Code and Codex plugin metadata and generated install guidance
- update the Claude marketplace command to the canonical repository name
- bump the plugin cache version from 0.3.3 to 0.3.4
- add repository validation that rejects the pre-rename slug, including split installer variables

## Why

The repository was renamed from `archastro-cli` to `archastro`. GitHub redirects old links, but public installers, plugin metadata, and documentation should resolve directly through the canonical repository.

## Verification

- 109 repository validation tests passed
- all six repository checks passed
- all 21 generated plugin files are in sync
- Bash and PowerShell installers emit canonical release URLs
- canonical raw installer URLs return HTTP 200
- shell syntax and `git diff --check` passed
- independent review found no blockers after installer coverage was added